### PR TITLE
Fix broken CI & code stuff after project name change

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -51,15 +51,15 @@ jobs:
         run: mkdir -p bin
       - name: Renaming binaries [Windows]
         if: matrix.os == 'windows-latest'
-        run: mv target/release/uad_gui.exe bin/uad_gui-${{ matrix.build_target }}${{ matrix.renderer }}.exe
+        run: mv target/release/uad-ng.exe bin/uad-ng-${{ matrix.build_target }}${{ matrix.renderer }}.exe
       - name: Renaming binaries [Others]
         if: matrix.os != 'windows-latest'
-        run: mv target/release/uad_gui bin/uad_gui${{ matrix.update_name }}-${{ matrix.build_target }}${{ matrix.renderer }}
+        run: mv target/release/uad-ng bin/uad-ng${{ matrix.update_name }}-${{ matrix.build_target }}${{ matrix.renderer }}
       - name: Tarball Linux/MacOS binary
         if: matrix.os != 'windows-latest'
-        run: tar -czf bin/uad_gui${{ matrix.update_name }}-${{ matrix.build_target }}${{ matrix.renderer }}{.tar.gz,}
+        run: tar -czf bin/uad-ng${{ matrix.update_name }}-${{ matrix.build_target }}${{ matrix.renderer }}{.tar.gz,}
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: uad_gui${{ matrix.update_name }}-${{ matrix.build_target }}${{ matrix.renderer }}
-          path: bin/uad_gui-*
+          name: uad-ng${{ matrix.update_name }}-${{ matrix.build_target }}${{ matrix.renderer }}
+          path: bin/uad-ng-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,16 @@ name: Continuous Integration
 on:
   push:
     paths:
-      - "**.rs"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "**.json"
+      - Cargo.lock
+      - Cargo.toml
+      - resources/assets/*.ttf
+      - src/**
   pull_request:
     paths:
-      - "**.rs"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "**.json"
+      - Cargo.lock
+      - Cargo.toml
+      - resources/assets/*.ttf
+      - src/**
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,10 @@ on:
     branches:
       - main
     paths:
-      - "**.rs"
-      - "Cargo.lock"
-      - "Cargo.toml"
+      - Cargo.lock
+      - Cargo.toml
+      - resources/assets/*.ttf
+      - src/**
     tags-ignore:
       - dev-build
 
@@ -18,6 +19,7 @@ jobs:
   build:
     uses: ./.github/workflows/build_artifacts.yml
   release:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs: build
     permissions:
@@ -29,11 +31,10 @@ jobs:
         with:
           path: bin
       - name: Create pre-release
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           body_path: ${{ github.workspace }}/CHANGELOG.md
-          files: bin/*/uad_gui-*
+          files: bin/*/uad-ng-*
           prerelease: true
       # - name: Update dev-build tag
       #   if: ${{ github.event_name == 'push' }}
@@ -47,6 +48,6 @@ jobs:
       #   uses: softprops/action-gh-release@v1
       #   with:
       #     generate_release_notes: true
-      #     files: bin/*/uad_gui-*
+      #     files: bin/*/uad-ng-*
       #     prerelease: true
       #     tag_name: ${{ env.dev_tag }}

--- a/src/core/update.rs
+++ b/src/core/update.rs
@@ -229,17 +229,17 @@ pub fn extract_binary_from_tar(archive_path: &Path, temp_file: &Path) -> io::Res
 pub const fn bin_name() -> &'static str {
     #[cfg(target_os = "windows")]
     {
-        "uad_gui.exe"
+        "uad-ng.exe"
     }
 
     #[cfg(target_os = "macos")]
     {
-        "uad_gui-macos"
+        "uad-ng-macos"
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
-        "uad_gui-linux"
+        "uad-ng-linux"
     }
 }
 

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -61,7 +61,7 @@ pub fn string_to_theme(theme: &str) -> Theme {
 }
 
 pub fn setup_uad_dir(dir: Option<PathBuf>) -> PathBuf {
-    let dir = dir.unwrap().join("uad-ng");
+    let dir = dir.unwrap().join("uad");
     fs::create_dir_all(&dir).expect("Can't create cache directory");
     dir
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,13 +57,15 @@ pub fn setup_logger() -> Result<(), fern::InitError> {
     let file_dispatcher = fern::Dispatch::new()
         .format(make_formatter(false))
         .level(default_log_level)
-        .level_for("uad_gui", log::LevelFilter::Debug)
+        // Rust compiler makes module names use _ instead of -
+        .level_for("uad_ng", log::LevelFilter::Debug)
         .chain(log_file);
 
     let stdout_dispatcher = fern::Dispatch::new()
         .format(make_formatter(true))
         .level(default_log_level)
-        .level_for("uad_gui", log::LevelFilter::Warn)
+        // Rust compiler makes module names use _ instead of -
+        .level_for("uad_ng", log::LevelFilter::Warn)
         .chain(std::io::stdout());
 
     fern::Dispatch::new()


### PR DESCRIPTION
We should've reviewed #124 more carefully, as most of this PR is in reaction to it.

Fixed:
- #124 changed cache/log directory to `uad-ng`, which I don't think we wanted (can be argued as bloat).
  Continuing to use `uad` would be preferable as users would have to manually delete the old one otherwise.
- The `build_artifacts` & `release` workflows were broken because they still used `uad_gui`.
- Log-level configuration for our own crate (uad) still used `uad_gui`

Additional changes in this PR:
- `release` workflow will no longer run at all on a normal push
  This workflow just creates pre-releases if we've pushed a tag. However, with the previous configuration, only the sub-step of creating a release was skipped, but the other steps for building & downloading artifacts were running every single time even if it was a normal push (i.e. not a tag). This was wasteful and noisy.
- fine-tuned `ci` workflow path configuration
  Earlier, this would run even if JSON files like `icons.json` and `uad_lists.json` changed, but neither of these files are part of the build itself. This was also wasteful/noisy.