### PR TITLE
fix(workflow): release.yml workflow's build job runs when it shouldn't

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,16 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - Cargo.lock
-      - Cargo.toml
-      - resources/assets/*.ttf
-      - src/**
-    tags-ignore:
-      - dev-build
-
-env:
-  dev_tag: dev-build
+    tags:
+      - v?[0-9]+.[0-9]+.[0-9]+ # semver
+      - '!dev-build' # not dev-build
 
 jobs:
   build:
@@ -37,18 +30,3 @@ jobs:
           body_path: ${{ github.workspace }}/CHANGELOG.md
           files: bin/*/uad-ng-*
           prerelease: true
-      # - name: Update dev-build tag
-      #   if: ${{ github.event_name == 'push' }}
-      #   run: |
-      #     git tag -d ${{ env.dev_tag }} || true
-      #     git push origin :refs/tags/${{ env.dev_tag }} || true
-      #     git tag ${{ env.dev_tag }}
-      #     git push origin ${{ env.dev_tag }}
-      # - name: Create dev-build release
-      #   if: ${{ github.event_name == 'push' }}
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     generate_release_notes: true
-      #     files: bin/*/uad-ng-*
-      #     prerelease: true
-      #     tag_name: ${{ env.dev_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   build:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     uses: ./.github/workflows/build_artifacts.yml
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Draft PR only because I'm not sure if skipping the `build` job would be better, or configuring the workflow itself to run only on tag pushes (instead of paths).

Example config for tags-only:
```yaml
on:
  push:
    branches:
      - main
    # no `paths` config
    tags:
      - v?[0-9]+.[0-9]+.[0-9]+ # important part
      - '!dev-build' # not dev-build
```
With this config, we won't need to have the `if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')` condition at all.