### PR TITLE
refactor: use if-let binding for getting package attributes

### DIFF
--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -28,13 +28,12 @@ pub fn fetch_packages(
         uad_list = UadList::Unlisted;
         removal = Removal::Unlisted;
 
-        if uad_lists.contains_key(p_name) {
-            description = &uad_lists.get(p_name).unwrap().description;
-            if description.is_empty() {
-                description = "[No description] : CONTRIBUTION WELCOMED";
-            };
-            uad_list = uad_lists.get(p_name).unwrap().list;
-            removal = uad_lists.get(p_name).unwrap().removal;
+        if let Some(package) = uad_lists.get(p_name) {
+            if !package.description.is_empty() {
+                description = &package.description
+            }
+            uad_list = package.list;
+            removal = package.removal;
         }
 
         if enabled_system_packages.contains(p_name) {


### PR DESCRIPTION
### Changes
- Use `if let` binding to get a package if it exists in the list and further access attributes
- No user facing changes