### PR TITLE
refactor: select optional user struct based on SDK version conditional

### DIFF
--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -240,11 +240,8 @@ pub fn apply_pkg_state_commands(
         },
         PackageState::All => vec![],
     };
-    if phone.android_sdk < 21 {
-        request_builder(&commands, &package.name, None)
-    } else {
-        request_builder(&commands, &package.name, Some(selected_user))
-    }
+    let user = (phone.android_sdk < 21).then_some(selected_user);
+    request_builder(&commands, &package.name, user)
 }
 
 pub fn request_builder(commands: &[&str], package: &str, user: Option<&User>) -> Vec<String> {


### PR DESCRIPTION
### Changes
- Select optional user struct based on SDK version conditional using the `then_some` method on the conditional itself
  -  Pass the optional to the request builder
- No user-facing changes