### PR TITLE
refactor: remove unused string inside enum variants

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -215,16 +215,14 @@ impl Application for UadGui {
                 match msg {
                     AboutMessage::UpdateUadLists => {
                         self.update_state.uad_list = UadListState::Downloading;
-                        self.apps_view.loading_state =
-                            ListLoadingState::DownloadingList(String::new());
+                        self.apps_view.loading_state = ListLoadingState::DownloadingList;
                         self.update(Message::AppsAction(AppsMessage::LoadUadList(true)))
                     }
                     AboutMessage::DoSelfUpdate => {
                         #[cfg(feature = "self-update")]
                         if self.update_state.self_update.latest_release.is_some() {
                             self.update_state.self_update.status = SelfUpdateStatus::Updating;
-                            self.apps_view.loading_state =
-                                ListLoadingState::_UpdatingUad(String::new());
+                            self.apps_view.loading_state = ListLoadingState::_UpdatingUad;
                             let bin_name = bin_name().to_owned();
                             let release = self
                                 .update_state
@@ -256,7 +254,7 @@ impl Application for UadGui {
                     s_device.android_sdk, s_device.model
                 );
                 info!("{:-^65}", "-");
-                self.apps_view.loading_state = ListLoadingState::FindingPhones(String::new());
+                self.apps_view.loading_state = ListLoadingState::FindingPhones;
 
                 #[allow(unused_must_use)]
                 {

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -26,20 +26,15 @@ pub struct PackageInfo {
     pub removal: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub enum LoadingState {
     DownloadingList,
+    #[default]
     FindingPhones,
     LoadingPackages,
     _UpdatingUad,
     Ready,
     RestoringDevice(String),
-}
-
-impl Default for LoadingState {
-    fn default() -> Self {
-        Self::FindingPhones
-    }
 }
 
 #[derive(Default, Debug, Clone)]

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -28,17 +28,17 @@ pub struct PackageInfo {
 
 #[derive(Debug, Clone)]
 pub enum LoadingState {
-    DownloadingList(String),
-    FindingPhones(String),
-    LoadingPackages(String),
-    _UpdatingUad(String),
-    Ready(String),
+    DownloadingList,
+    FindingPhones,
+    LoadingPackages,
+    _UpdatingUad,
+    Ready,
     RestoringDevice(String),
 }
 
 impl Default for LoadingState {
     fn default() -> Self {
-        Self::FindingPhones(String::new())
+        Self::FindingPhones
     }
 }
 
@@ -129,7 +129,7 @@ impl List {
                     selected_device.android_sdk, selected_device.model
                 );
                 info!("{:-^65}", "-");
-                self.loading_state = LoadingState::DownloadingList(String::new());
+                self.loading_state = LoadingState::DownloadingList;
                 Command::perform(
                     Self::init_apps_view(remote, selected_device.clone()),
                     Message::LoadPhonePackages,
@@ -137,7 +137,7 @@ impl List {
             }
             Message::LoadPhonePackages(list_box) => {
                 let (uad_list, list_state) = list_box;
-                self.loading_state = LoadingState::LoadingPackages(String::new());
+                self.loading_state = LoadingState::LoadingPackages;
                 self.uad_lists = uad_list.clone();
                 *list_update_state = list_state;
                 Command::perform(
@@ -153,7 +153,7 @@ impl List {
                 self.selected_list = Some(UadList::All);
                 self.selected_user = Some(User::default());
                 Self::filter_package_lists(self);
-                self.loading_state = LoadingState::Ready(String::new());
+                self.loading_state = LoadingState::Ready;
                 Command::none()
             }
             Message::ToggleAllSelected(selected) => {
@@ -289,27 +289,24 @@ impl List {
         selected_device: &Phone,
     ) -> Element<Message, Renderer<Theme>> {
         match &self.loading_state {
-            LoadingState::DownloadingList(_) => {
+            LoadingState::DownloadingList => {
                 let text = "Downloading latest UAD-ng lists from GitHub. Please wait...";
                 waiting_view(settings, text, true)
             }
-            LoadingState::FindingPhones(_) => {
-                let text = "Finding connected devices...";
-                waiting_view(settings, text, false)
+            LoadingState::FindingPhones => {
+                waiting_view(settings, "Finding connected devices...", true)
             }
-            LoadingState::LoadingPackages(_) => {
+            LoadingState::LoadingPackages => {
                 let text = "Pulling packages from the device. Please wait...";
-                waiting_view(settings, text, false)
+                waiting_view(settings, text, true)
             }
-            LoadingState::_UpdatingUad(_) => {
-                let text = "Updating UAD-ng. Please wait...";
-                waiting_view(settings, text, false)
+            LoadingState::_UpdatingUad => {
+                waiting_view(settings, "Updating UAD-ng. Please wait...", true)
             }
-            LoadingState::RestoringDevice(output) => {
-                let text = format!("Restoring device: {output}");
-                waiting_view(settings, &text, false)
+            LoadingState::RestoringDevice(device) => {
+                waiting_view(settings, &format!("Restoring device: {device}"), true)
             }
-            LoadingState::Ready(_) => {
+            LoadingState::Ready => {
                 let search_packages = text_input("Search packages...", &self.input_value)
                     .width(Length::Fill)
                     .on_input(Message::SearchInputChanged)

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -289,17 +289,17 @@ impl List {
                 waiting_view(settings, text, true)
             }
             LoadingState::FindingPhones => {
-                waiting_view(settings, "Finding connected devices...", true)
+                waiting_view(settings, "Finding connected devices...", false)
             }
             LoadingState::LoadingPackages => {
                 let text = "Pulling packages from the device. Please wait...";
-                waiting_view(settings, text, true)
+                waiting_view(settings, text, false)
             }
             LoadingState::_UpdatingUad => {
-                waiting_view(settings, "Updating UAD-ng. Please wait...", true)
+                waiting_view(settings, "Updating UAD-ng. Please wait...", false)
             }
             LoadingState::RestoringDevice(device) => {
-                waiting_view(settings, &format!("Restoring device: {device}"), true)
+                waiting_view(settings, &format!("Restoring device: {device}"), false)
             }
             LoadingState::Ready => {
                 let search_packages = text_input("Search packages...", &self.input_value)

--- a/src/gui/widgets/navigation_menu.rs
+++ b/src/gui/widgets/navigation_menu.rs
@@ -76,7 +76,7 @@ pub fn nav_menu<'a>(
         .style(style::Button::Primary);
 
     let device_list_text = match apps_view.loading_state {
-        ListLoadingState::FindingPhones(_) => text("finding connected phone..."),
+        ListLoadingState::FindingPhones => text("finding connected phone..."),
         _ => text("no devices/emulators found"),
     };
 


### PR DESCRIPTION
### Changes
- Removes unused `String` from `LoadingState` variants that never use the inner string
- Use the derive macro to specify the default value instead of manual implementation