### PR TITLE
fix: exit when adb is not found

### DIFF
--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -68,8 +68,10 @@ pub fn adb_shell_command(shell: bool, args: &str) -> Result<String, String> {
 
     match command.output() {
         Err(e) => {
+            // TODO: better error handling with anyhow + thiserror
             error!("ADB: {}", e);
-            Err("ADB was not found".to_string())
+            error!("ADB was not found");
+            std::process::exit(1);
         }
         Ok(o) => {
             if o.status.success() {


### PR DESCRIPTION
Fixes: #188

The program prematurely exits with a status code of 1 when ADB is not found.