### PR TITLE
fix: strip `v` version prefix when checking for updates

### DIFF
--- a/src/core/update.rs
+++ b/src/core/update.rs
@@ -186,7 +186,8 @@ pub fn get_latest_release() -> Result<Option<Release>, ()> {
             )
             .map_err(|_| ())?;
 
-            let release_version = release.tag_name.strip_prefix("v").unwrap_or(&release.tag_name);
+            let release_version = release.tag_name.strip_prefix('v').unwrap_or(&release.tag_name);
+            
             if release_version != "dev-build"
                 && release_version > env!("CARGO_PKG_VERSION")
             {

--- a/src/core/update.rs
+++ b/src/core/update.rs
@@ -185,8 +185,10 @@ pub fn get_latest_release() -> Result<Option<Release>, ()> {
                     .clone(),
             )
             .map_err(|_| ())?;
-            if release.tag_name.as_str() != "dev-build"
-                && release.tag_name.as_str() > env!("CARGO_PKG_VERSION")
+
+            let release_version = release.tag_name.strip_prefix("v").unwrap_or(&release.tag_name);
+            if release_version != "dev-build"
+                && release_version > env!("CARGO_PKG_VERSION")
             {
                 Ok(Some(release))
             } else {

--- a/src/core/update.rs
+++ b/src/core/update.rs
@@ -187,7 +187,7 @@ pub fn get_latest_release() -> Result<Option<Release>, ()> {
             .map_err(|_| ())?;
 
             let release_version = release.tag_name.strip_prefix('v').unwrap_or(&release.tag_name);
-            
+
             if release_version != "dev-build"
                 && release_version > env!("CARGO_PKG_VERSION")
             {


### PR DESCRIPTION
Fixes #224

### Changes
- The `v` prefix from the version name is ignored if it exists. Should prevent erroneous update version.