### PR TITLE
fix: allow the app to display logs when launced from the terminal on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ iced = { version = "^0.10.0", features = ["advanced", "image"] }
 flate2 = { version = "^1", optional = true }
 tar = { version = "^0.4", optional = true }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "^0.52.0", features = ["Win32_System_Console", "Win32_Foundation"] }
+
 [profile.release]
 opt-level = "s"
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ flate2 = { version = "^1", optional = true }
 tar = { version = "^0.4", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "^0.52.0", features = ["Win32_System_Console", "Win32_Foundation"] }
+win32console = "^0.1.5"
 
 [profile.release]
 opt-level = "s"

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,8 @@ fn main() -> iced::Result {
 }
 
 pub fn setup_logger() -> Result<(), fern::InitError> {
+    attach_windows_console();
+    
     let colors = ColoredLevelConfig::new().info(Color::Green);
 
     let make_formatter = |use_colors: bool| {
@@ -74,4 +76,21 @@ pub fn setup_logger() -> Result<(), fern::InitError> {
         .apply()?;
 
     Ok(())
+}
+
+/// (Windows) Allow the application to display logs to the terminal
+/// regardless if it was compiled with `windows_subsystem = "windows"`.
+/// 
+/// This is a no-op when compiled to non-windows targets.
+fn attach_windows_console() {
+    #[cfg(target_os = "windows")]
+    {
+        use windows_sys::Win32::System::Console::{AttachConsole, ATTACH_PARENT_PROCESS};
+
+        // # SAFETY:
+        // According to the docs: https://learn.microsoft.com/en-us/windows/console/attachconsole
+        //
+        // AttachConsole doesn't have any footguns, so calling it like this is fine.
+        let _ = unsafe { AttachConsole(ATTACH_PARENT_PROCESS) };
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ fn main() -> iced::Result {
 
 pub fn setup_logger() -> Result<(), fern::InitError> {
     attach_windows_console();
-    
+
     let colors = ColoredLevelConfig::new().info(Color::Green);
 
     let make_formatter = |use_colors: bool| {
@@ -80,13 +80,13 @@ pub fn setup_logger() -> Result<(), fern::InitError> {
 
 /// (Windows) Allow the application to display logs to the terminal
 /// regardless if it was compiled with `windows_subsystem = "windows"`.
-/// 
+///
 /// This is a no-op when compiled to non-windows targets.
 fn attach_windows_console() {
     #[cfg(target_os = "windows")]
     {
         use win32console::console::WinConsole;
-        
+
         const ATTACH_PARENT_PROCESS: u32 = 0xFFFFFFFF;
         let _ = WinConsole::attach_console(ATTACH_PARENT_PROCESS);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,12 +85,9 @@ pub fn setup_logger() -> Result<(), fern::InitError> {
 fn attach_windows_console() {
     #[cfg(target_os = "windows")]
     {
-        use windows_sys::Win32::System::Console::{AttachConsole, ATTACH_PARENT_PROCESS};
-
-        // # SAFETY:
-        // According to the docs: https://learn.microsoft.com/en-us/windows/console/attachconsole
-        //
-        // AttachConsole doesn't have any footguns, so calling it like this is fine.
-        let _ = unsafe { AttachConsole(ATTACH_PARENT_PROCESS) };
+        use win32console::console::WinConsole;
+        
+        const ATTACH_PARENT_PROCESS: u32 = 0xFFFFFFFF;
+        let _ = WinConsole::attach_console(ATTACH_PARENT_PROCESS);
     }
 }


### PR DESCRIPTION
fixes: #237

While `#![windows_subsystem = "windows"]` is fine since we don't want the app to create the terminal on startup, this has the consequence of outright disabling terminal output, even if we launch it from the console.

The proposed fix uses [`windows-sys`](https://crates.io/crates/windows-sys) to attach the process' stout to any available console.
Reference: https://learn.microsoft.com/en-us/windows/console/attachconsole

While this introduces a new dependency, since they're raw FFI calls for the windows-api, they should add little to no overhead.