### PR TITLE
fix: escape double quotes in json file

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -4943,7 +4943,7 @@
   {
     "id": "com.samsung.android.smartface",
     "list": "Oem",
-    "description": "SmartFaceService\nUsed to automatically detects faces when using the Samsung camera\nIt might be related to "Keep screen on while viewing" under Motions and gestures in Settings.\nNOTE: This package has nothing to do with face unlock (com.samsung.android.bio.face.service)\n",
+    "description": "SmartFaceService\nUsed to automatically detects faces when using the Samsung camera\nIt might be related to \"Keep screen on while viewing\" under Motions and gestures in Settings.\nNOTE: This package has nothing to do with face unlock (com.samsung.android.bio.face.service)\n",
     "dependencies": [],
     "neededBy": [],
     "labels": [],


### PR DESCRIPTION
Fixes regression introduced in #192, escapes double quotes so that the JSON file can be parsed.