### PR TITLE
fix: pass user flag when sdk version is 21 or above

### DIFF
--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -240,7 +240,7 @@ pub fn apply_pkg_state_commands(
         },
         PackageState::All => vec![],
     };
-    let user = (phone.android_sdk < 21).then_some(selected_user);
+    let user = (phone.android_sdk >= 21).then_some(selected_user);
     request_builder(&commands, &package.name, user)
 }
 


### PR DESCRIPTION
fixes regression introduced in 6ffba9d40efad82c8129904ef38385c9ae30f288