### PR TITLE
chore(issue-templates): add documentation template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,10 @@
+---
+name: Documentation
+about: You want to improve the documentation which is either a Markdown file or the Wiki
+title: "docs(scope): "
+labels: documentation
+assignees: ""
+---
+
+**Describe the documentation you want to change**
+A clear description of what you want to change.


### PR DESCRIPTION
Currently, there's no issue template for documentational things, and since we've (consciously) disabled blank issues, it's hard to keep track of documentation that needs to be written. An alternative for this is to use GitHub Projects for this, but that's not as accessible.