### PR TITLE
fix(ci): sha256sum errors and overwrites

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -53,13 +53,16 @@ jobs:
       - name: Tarball Linux/MacOS binary
         if: matrix.os != 'windows-latest'
         run: tar -czf bin/uad-ng${{ matrix.update_name }}-${{ matrix.build_target }}{.tar.gz,}
+      - name: Install coreutils for macOS
+        if: matrix.os == 'macos-latest'
+        run: brew install coreutils
       - name: Create checksums for binaries and archives [Windows]
         if: matrix.os == 'windows-latest'
         run: sha256sum bin/uad-ng-${{ matrix.build_target }}.exe | tee bin/uad-ng-${{ matrix.build_target }}-checksum.txt
       - name: Create checksums for binaries and archives [Others]
         if: matrix.os != 'windows-latest'
-        run: >
-          sha256sum bin/uad-ng${{ matrix.update_name }}-${{ matrix.build_target }} | tee bin/uad-ng${{ matrix.update_name }}-${{ matrix.build_target }}-checksum 
+        run: |
+          sha256sum bin/uad-ng${{ matrix.update_name }}-${{ matrix.build_target }} | tee bin/uad-ng${{ matrix.update_name }}-${{ matrix.build_target }}-checksum
           sha256sum bin/uad-ng${{ matrix.update_name }}-${{ matrix.build_target }}.tar.gz | tee bin/uad-ng${{ matrix.update_name }}-${{ matrix.build_target }}.tar.gz-checksum
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The sha256 sums were overwriting the tarballs because folded block scalars (>) were used instead of literal block scalars (|).

Also added a step to install coreutils if on macos so we have sha256sum on the mac environment