### PR TITLE
chore(issue-templates): fix typos in labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-add-new-packages.yml
+++ b/.github/ISSUE_TEMPLATE/3-add-new-packages.yml
@@ -1,7 +1,7 @@
 name: Add new package(s)
 description: You want to add new apps to the debloat list
 title: "pkg(scope): "
-labels: ["package:addition"]
+labels: ["package::addition"]
 body:
 - type: markdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/5-update-apps-description-or-recommendation.yml
+++ b/.github/ISSUE_TEMPLATE/5-update-apps-description-or-recommendation.yml
@@ -1,7 +1,7 @@
 name: Update apps description or recommendation
 description: You want to improve/update a description/recommendation
 title: "pkg(scope): "
-labels: ["package:documentation"]
+labels: ["package::documentation"]
 body:
 - type: markdown
   attributes:


### PR DESCRIPTION
This prevented the label from being automatically assigned when an issue was created.