### PR TITLE
pkg(`com.hoffnung`): change removal

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -23613,7 +23613,7 @@
   },
   "com.hoffnung": {
     "description": "TPMS\nRemote Config Test. Instead Uninstall better Disable this app\nbecause it uninstalling cause screen flicker",
-    "removal": "Recommended",
+    "removal": "Expert",
     "list": "Oem",
     "dependencies": [],
     "neededBy": [],


### PR DESCRIPTION
In my case, it cause the screen went blank, but the power option UI is still accessible on my Infinix phone. But there's a worse case: https://xdaforums.com/t/infinix-note-10-uninstall-tpms-com-hoffnung-package-causes-bootloop.4647456/

So, just don't recommend 'com.hoffnung'