### PR TITLE
feat(ui): consistent buttons placements and "update" wording

### DIFF
--- a/src/gui/widgets/navigation_menu.rs
+++ b/src/gui/widgets/navigation_menu.rs
@@ -78,8 +78,8 @@ pub fn nav_menu<'a>(
         .style(style::Button::Primary);
 
     let device_list_text = match apps_view.loading_state {
-        ListLoadingState::FindingPhones => text("finding connected phone..."),
-        _ => text("no devices/emulators found"),
+        ListLoadingState::FindingPhones => text("Finding connected devices..."),
+        _ => text("No devices/emulators found"),
     };
 
     let row = match selected_device {

--- a/src/gui/widgets/navigation_menu.rs
+++ b/src/gui/widgets/navigation_menu.rs
@@ -84,8 +84,8 @@ pub fn nav_menu<'a>(
 
     let row = match selected_device {
         Some(phone) => row![
-            apps_refresh_tooltip,
             reboot_btn,
+            apps_refresh_tooltip,
             pick_list(device_list, Some(phone), Message::DeviceSelected,),
             Space::new(Length::Fill, Length::Shrink),
             uad_version_text,

--- a/src/gui/widgets/navigation_menu.rs
+++ b/src/gui/widgets/navigation_menu.rs
@@ -44,7 +44,7 @@ pub fn nav_menu<'a>(
             Text::new("Updating please wait...")
         } else {
             Text::new(format!(
-                "New UAD-ng version available {} -> {}",
+                "Update available: {} -> {}",
                 env!("CARGO_PKG_VERSION"),
                 r.tag_name
             ))


### PR DESCRIPTION
 - moved buttons, so that they are consistent if device is not found vs found. Ln. nr. 101, 102
 - changed wording for update info, on small window size previous wording takes a lot of screen and pushes buttons out of boundaries of window. Updated is not ideal, but takes less screen.