### PR TITLE
refactor(app): use if-else instead of match over booleans

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -344,15 +344,9 @@ impl Application for UadGui {
             }
             Message::ADBSatisfied(result) => {
                 self.adb_satisfied = result;
-                if result {
-                    self.update(Message::AppsAction(AppsMessage::ADBSatisfied(
-                        self.adb_satisfied,
-                    )))
-                } else {
-                    self.update(Message::AppsAction(AppsMessage::ADBSatisfied(
-                        self.adb_satisfied,
-                    )))
-                }
+                self.update(Message::AppsAction(AppsMessage::ADBSatisfied(
+                    self.adb_satisfied,
+                )))
             }
             Message::Nothing => Command::none(),
         }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -344,13 +344,14 @@ impl Application for UadGui {
             }
             Message::ADBSatisfied(result) => {
                 self.adb_satisfied = result;
-                match result {
-                    true => self.update(Message::AppsAction(AppsMessage::ADBSatisfied(
+                if result {
+                    self.update(Message::AppsAction(AppsMessage::ADBSatisfied(
                         self.adb_satisfied,
-                    ))),
-                    false => self.update(Message::AppsAction(AppsMessage::ADBSatisfied(
+                    )))
+                } else {
+                    self.update(Message::AppsAction(AppsMessage::ADBSatisfied(
                         self.adb_satisfied,
-                    ))),
+                    )))
                 }
             }
             Message::Nothing => Command::none(),

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -314,20 +314,21 @@ impl List {
                 let text = "Downloading latest UAD-ng lists from GitHub. Please wait...";
                 waiting_view(settings, text, true, style::Text::Default)
             }
-            LoadingState::FindingPhones => match self.is_adb_satisfied {
-                true => waiting_view(
+            LoadingState::FindingPhones => if self.is_adb_satisfied {
+                waiting_view(
                     settings,
                     "Finding connected devices...",
                     false,
                     style::Text::Default,
-                ),
-                false => waiting_view(
+                )
+            } else {
+                waiting_view(
                     settings,
                     "ADB is not installed on your system, install ADB and relaunch application.",
                     false,
                     style::Text::Danger,
-                ),
-            },
+                )
+            }
             LoadingState::LoadingPackages => {
                 let text = "Pulling packages from the device. Please wait...";
                 waiting_view(settings, text, false, style::Text::Default)

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -314,20 +314,22 @@ impl List {
                 let text = "Downloading latest UAD-ng lists from GitHub. Please wait...";
                 waiting_view(settings, text, true, style::Text::Default)
             }
-            LoadingState::FindingPhones => if self.is_adb_satisfied {
-                waiting_view(
-                    settings,
-                    "Finding connected devices...",
-                    false,
-                    style::Text::Default,
-                )
-            } else {
-                waiting_view(
-                    settings,
-                    "ADB is not installed on your system, install ADB and relaunch application.",
-                    false,
-                    style::Text::Danger,
-                )
+            LoadingState::FindingPhones => {
+                if self.is_adb_satisfied {
+                    waiting_view(
+                        settings,
+                        "Finding connected devices...",
+                        false,
+                        style::Text::Default,
+                    )
+                } else {
+                    waiting_view(
+                        settings,
+                        "ADB is not installed on your system, install ADB and relaunch application.",
+                        false,
+                        style::Text::Danger,
+                    )
+                }
             }
             LoadingState::LoadingPackages => {
                 let text = "Pulling packages from the device. Please wait...";


### PR DESCRIPTION
Use if-else blocks instead of match for booleans