### PR TITLE
feat: graphically display error when adb command fails

### DIFF
--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -101,15 +101,22 @@ pub enum CommandType {
     PackageManager(PackageInfo),
     Shell,
 }
+
+#[derive(Debug, Clone)]
+pub enum AdbError {
+    Generic(String),
+}
+
 pub async fn perform_adb_commands(
     action: String,
     command_type: CommandType,
-) -> Result<CommandType, ()> {
-    let label = match command_type {
-        CommandType::PackageManager(ref p) => p.removal.to_string(),
-        CommandType::Shell => "Shell".to_string(),
+) -> Result<CommandType, AdbError> {
+    let label = match &command_type {
+        CommandType::PackageManager(p) => &p.removal,
+        CommandType::Shell => "Shell",
     };
 
+    // HERE FUEGO!!
     match adb_shell_command(true, &action) {
         Ok(o) => {
             // On old devices, adb commands can return the '0' exit code even if there
@@ -118,18 +125,23 @@ pub async fn perform_adb_commands(
             // Some commands are even killed by ADB before finishing and UAD-ng can't catch
             // the output.
             if ["Error", "Failure"].iter().any(|&e| o.contains(e)) {
-                error!("[{}] {} -> {}", label, action, o);
-                Err(())
-            } else {
-                info!("[{}] {} -> {}", label, action, o);
-                Ok(command_type)
+                return Err(AdbError::Generic(format!(
+                    "[{}] {} -> {}",
+                    label, action, o
+                )));
             }
+
+            info!("[{}] {} -> {}", label, action, o);
+            Ok(command_type)
         }
         Err(err) => {
             if !err.contains("[not installed for") {
-                error!("[{}] {} -> {}", label, action, err);
+                return Err(AdbError::Generic(format!(
+                    "[{}] {} -> {}",
+                    label, action, err
+                )));
             }
-            Err(())
+            Err(AdbError::Generic(err.to_string()))
         }
     }
 }

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -115,7 +115,6 @@ pub async fn perform_adb_commands(
         CommandType::Shell => "Shell",
     };
 
-    // HERE FUEGO!!
     match adb_shell_command(true, &action) {
         Ok(o) => {
             // On old devices, adb commands can return the '0' exit code even if there

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -101,6 +101,7 @@ pub enum CommandType {
     Shell,
 }
 
+/// An enum to contain different variants for errors yielded by ADB.
 #[derive(Debug, Clone)]
 pub enum AdbError {
     Generic(String),

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -497,7 +497,7 @@ impl List {
                     .align_items(Alignment::Center)
                 };
                 if self.selection_modal {
-                    Modal::new(
+                    return Modal::new(
                         content.padding(10),
                         self.apply_selection_modal(
                             selected_device,
@@ -506,8 +506,9 @@ impl List {
                         ),
                     )
                     .on_blur(Message::ModalHide)
-                    .into()
-                } else if let Some(err) = &self.error_modal {
+                    .into();
+                }
+                if let Some(err) = &self.error_modal {
                     let title_ctn = container(
                         row![text("Failed to perform ADB operation").size(24)]
                             .align_items(Alignment::Center),
@@ -518,23 +519,25 @@ impl List {
                     .center_y()
                     .center_x();
 
-                    let modal_btn_row =
-                        container(row![button(text("Cancel")).on_press(Message::ModalHide)])
+                    let modal_btn_row = row![button(
+                        text("Close")
                             .width(Length::Fill)
-                            .style(style::Container::Frame)
-                            .padding([10, 0, 10, 0])
-                            .center_y()
-                            .center_x();
+                            .horizontal_alignment(alignment::Horizontal::Center),
+                    )
+                    .width(Length::Fill)
+                    .padding(10)
+                    .on_press(Message::ModalHide)]
+                    .padding([10, 0, 0, 0]);
 
-                    let ctn = container(column![title_ctn, text(err), modal_btn_row])
+                    let text_box = scrollable(text(err).width(Length::Fill)).height(400);
+
+                    let ctn = container(column![title_ctn, text_box, modal_btn_row])
                         .height(Length::Shrink)
                         .max_height(700)
                         .padding(10)
-                        .style(style::Container::Background);
+                        .style(style::Container::Frame);
 
-                    Modal::new(content.padding(20), ctn)
-                        .on_blur(Message::ModalHide)
-                        .into()
+                    Modal::new(content, ctn).on_blur(Message::ModalHide).into()
                 } else {
                     container(content).height(Length::Fill).padding(10).into()
                 }

--- a/src/gui/views/settings.rs
+++ b/src/gui/views/settings.rs
@@ -1,3 +1,5 @@
+use crate::core::sync::AdbError;
+
 use crate::core::config::{BackupSettings, Config, DeviceSettings, GeneralSettings};
 use crate::core::save::{
     backup_phone, list_available_backup_user, list_available_backups, restore_backup, BACKUP_DIR,
@@ -41,7 +43,7 @@ pub enum Message {
     BackupSelected(DisplayablePath),
     BackupDevice,
     RestoreDevice,
-    RestoringDevice(Result<CommandType, ()>),
+    RestoringDevice(Result<CommandType, AdbError>),
     DeviceBackedUp(Result<(), String>),
 }
 


### PR DESCRIPTION
This is more or less scaffold code to display the raw error if an ADB command fails.
Related to #37
- We use an enum to classify these errors. Currently it only has one error type as `Generic`.
- Any ADB error will display a modal with the raw error trace of the ADB command itself. 

![Screenshot from 2024-04-05 19-25-56](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/assets/107522312/dfbf9116-0a09-4c03-b1f2-ac5fa511db76)
