### PR TITLE
fix(ci): upload artifacts correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Downloads artifacts
         uses: actions/download-artifact@v4
-      - name: Create pre-release
+      - name: Create release
         uses: softprops/action-gh-release@v1
         with:
-          files: uad-ng-*
+          files: uad-ng-*/*
           generate_release_notes: true


### PR DESCRIPTION
Path was wrong, too much got axed when we were getting rid of /bin/
Tested in my fork

Fixes #380 