### PR TITLE
fix(ci): incorrect filename being used for UAD list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - Cargo.lock
       - Cargo.toml
       - resources/assets/*.ttf
-      - resources/assets/uad_list.json
+      - resources/assets/uad_lists.json
       - src/**
   pull_request:
     paths:


### PR DESCRIPTION
The incorrect filename caused the CI job to not run whenever a PR has been opened that made changes to the UAD list. `uad_list.json` was used instead of `uad_lists.json`.