### PR TITLE
build(ci): fix ci not running for user-submitted PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
       - Cargo.lock
       - Cargo.toml
       - resources/assets/*.ttf
+      - resources/assets/uad_lists.json
       - src/**
 
 jobs:


### PR DESCRIPTION
`- resources/assets/uad_lists.json` was missing here: https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/blob/main/.github/workflows/ci.yml#L11. As you can see, the CI is not running for user-submitted PRs: https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/492. This should definitely be running, as users also tend to sometimes make a mistake, therefore messing up the JSON.

This PR fixes that issue, so now it's running for every PR, not matter if it comes from our organization or not.