### PR TITLE
pkg(com.lge.ims): change description and removal

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -18044,8 +18044,8 @@
     "labels": []
   },
   "com.lge.ims": {
-    "description": "LG IMS\nIt's not a good app because it has a lot of debugging stuff.",
-    "removal": "Recommended",
+    "description": "LG IMS\nIt's not a good app because it has a lot of debugging stuff.\nBreaks calls.",
+    "removal": "Expert",
     "list": "Oem",
     "dependencies": [],
     "neededBy": [],


### PR DESCRIPTION
Removing this package causes calls to not work on my Verizon LG G6 (VS988).