### PR TITLE
chore(bug-template): Include OS, WM, and DE

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -48,8 +48,6 @@ body:
     label: Desktop Environment
     description: Please, fill it if OS is Linux
     placeholder: GNOME 46, KDE Plasma 4, etc...
-  validations:
-    required: true
 - type: textarea
   id: logfiles
   attributes:

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -11,7 +11,7 @@ body:
   id: what-happened
   attributes:
     label: Describe the bug
-    description: A clear and concise description of what the bug is
+    description: A clear and concise description of what the bug is, and how to reproduce it
   validations:
     required: true
 - type: textarea
@@ -26,6 +26,30 @@ body:
   attributes:
     label: You have a solution?
     description: What to do to fix the issue.
+- type: dropdown
+  id: os
+  attributes:
+    label: Operating System
+    options:
+      - Linux
+      - MacOS
+      - Windows
+  validations:
+    required: true
+- type: input
+  id: wm
+  attributes:
+    label: Window Manager
+    description: Please, fill it if OS is Linux
+    placeholder: Wayland, xorg, etc...
+- type: input
+  id: de
+  attributes:
+    label: Desktop Environment
+    description: Please, fill it if OS is Linux
+    placeholder: GNOME 46, KDE Plasma 4, etc...
+  validations:
+    required: true
 - type: textarea
   id: logfiles
   attributes:


### PR DESCRIPTION
operating-sys is required because UAD is only officially supported for 3 OSes.

desktop-environment and window-manager are suggested, because they may help debug GUI problems