### PR TITLE
pkg(com.lge.sui.widget): change description and removal

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -17908,8 +17908,8 @@
     "labels": []
   },
   "com.lge.sui.widget": {
-    "description": "It's probably a clock widget but in the code, I see it's for calendar widgets.",
-    "removal": "Recommended",
+    "description": "Removing this package causes the clock app to crash when trying to set an alarm for a specific date instead of a day in the week.",
+    "removal": "Advanced",
     "list": "Oem",
     "dependencies": [],
     "neededBy": [],

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -17908,7 +17908,7 @@
     "labels": []
   },
   "com.lge.sui.widget": {
-    "description": "Removing this package causes the clock app to crash when trying to set an alarm for a specific date instead of a day in the week.",
+    "description": "Removing this package causes the clock app to crash when trying to set an alarm for a specific date instead of a day of the week.",
     "removal": "Advanced",
     "list": "Oem",
     "dependencies": [],


### PR DESCRIPTION
Removing this package causes the clock app to crash when trying to set an alarm to a specific date. Tested on my LG G6.