### PR TITLE
refactor(app_id): specify `iced::Settings.id`

### DIFF
--- a/src/core/update.rs
+++ b/src/core/update.rs
@@ -1,3 +1,5 @@
+use crate::core::utils::NAME;
+
 use serde::Deserialize;
 
 #[cfg(feature = "self-update")]
@@ -108,12 +110,12 @@ pub async fn download_update_to_temp_file(
         let archive_path = current_bin_path.parent().ok_or(())?.join(&asset_name);
 
         if let Err(e) = download_file(asset.download_url, archive_path.clone()).await {
-            error!("Couldn't download UAD-ng update: {}", e);
+            error!("Couldn't download {NAME} update: {}", e);
             return Err(());
         }
 
         if extract_binary_from_tar(&archive_path, &download_path).is_err() {
-            error!("Couldn't extract UAD-ng release tarball");
+            error!("Couldn't extract {NAME} release tarball");
             return Err(());
         }
 
@@ -131,7 +133,7 @@ pub async fn download_update_to_temp_file(
             .ok_or(())?;
 
         if let Err(e) = download_file(asset.download_url, download_path.clone()).await {
-            error!("Couldn't download UAD-ng update: {}", e);
+            error!("Couldn't download {NAME} update: {}", e);
             return Err(());
         }
     }
@@ -177,7 +179,7 @@ pub fn get_latest_release() -> Result<Option<Release>, ()> {
 // to only get the latest release
 #[cfg(feature = "self-update")]
 pub fn get_latest_release() -> Result<Option<Release>, ()> {
-    debug!("Checking for UAD-ng update");
+    debug!("Checking for {NAME} update");
 
     match ureq::get("https://api.github.com/repos/Universal-Debloater-Alliance/universal-android-debloater/releases/latest")
         .call()
@@ -201,7 +203,7 @@ pub fn get_latest_release() -> Result<Option<Release>, ()> {
             }
         }
         Err(_) => {
-            debug!("Failed to check UAD-ng update");
+            debug!("Failed to check {NAME} update");
             Err(())
         }
     }

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -9,6 +9,13 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::{fmt, fs};
 
+/// Canonical name of:
+/// - application
+/// - program
+/// - executable binary (with proper capitalization)
+/// - main window
+/// - crate (with proper capitalization)
+pub const NAME: &str = "UAD-ng";
 /// Global environment variable to keep
 /// track of the current device serial.
 pub const ANDROID_SERIAL: &str = "ANDROID_SERIAL";

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -388,6 +388,7 @@ impl UadGui {
         };
 
         Self::run(Settings {
+            id: Some(String::from("UAD-ng")),
             window: Window {
                 size: iced::Size {
                     width: 950.0,

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -6,7 +6,7 @@ use crate::core::sync::{get_devices_list, initial_load, perform_adb_commands, Co
 use crate::core::theme::Theme;
 use crate::core::uad_lists::UadListState;
 use crate::core::update::{get_latest_release, Release, SelfUpdateState, SelfUpdateStatus};
-use crate::core::utils::{string_to_theme, ANDROID_SERIAL};
+use crate::core::utils::{string_to_theme, ANDROID_SERIAL, NAME};
 
 use iced::advanced::graphics::image::image_rs::ImageFormat;
 use iced::font;
@@ -274,7 +274,7 @@ impl Application for UadGui {
             }
             #[cfg(feature = "self-update")]
             Message::_NewReleaseDownloaded(res) => {
-                debug!("UAD-ng update has been downloaded!");
+                debug!("{NAME} update has been downloaded!");
 
                 if let Ok((relaunch_path, cleanup_path)) = res {
                     // Remove first arg, which is path to binary. We don't use this first
@@ -308,11 +308,11 @@ impl Application for UadGui {
                             if let Err(e) = remove_file(cleanup_path) {
                                 error!("Could not remove temp update file: {}", e);
                             }
-                            error!("Failed to update UAD-ng: {}", error);
+                            error!("Failed to update {NAME}: {}", error);
                         }
                     }
                 } else {
-                    error!("Failed to update UAD-ng!");
+                    error!("Failed to update {NAME}!");
                     #[allow(unused_must_use)]
                     {
                         self.update(Message::AppsAction(AppsMessage::UpdateFailed));
@@ -388,7 +388,7 @@ impl UadGui {
         };
 
         Self::run(Settings {
-            id: Some(String::from("UAD-ng")),
+            id: Some(String::from(NAME)),
             window: Window {
                 size: iced::Size {
                     width: 950.0,

--- a/src/gui/views/about.rs
+++ b/src/gui/views/about.rs
@@ -1,6 +1,6 @@
 use crate::core::helpers::button_primary;
 use crate::core::theme::Theme;
-use crate::core::utils::{last_modified_date, open_url};
+use crate::core::utils::{last_modified_date, open_url, NAME};
 use crate::gui::{style, UpdateState};
 use crate::CACHE_DIR;
 use iced::widget::{column, container, row, text, Space};
@@ -28,7 +28,7 @@ impl About {
         // other events are handled by UadGui update()
     }
     pub fn view(&self, update_state: &UpdateState) -> Element<Message, Theme, Renderer> {
-        let about_text = text("Universal Android Debloater Next Generation (UAD-ng) is a free and open-source community project \naiming at simplifying the removal of pre-installed apps on any Android device.",);
+        let about_text = text(format!("Universal Android Debloater Next Generation ({NAME}) is a free and open-source community project \naiming at simplifying the removal of pre-installed apps on any Android device."));
 
         let descr_container = container(about_text)
             .width(Length::Fill)
@@ -37,7 +37,7 @@ impl About {
 
         let date = last_modified_date(CACHE_DIR.join("uad_lists.json"));
         let uad_list_text =
-            text(format!("UAD-ng package list: v{}", date.format("%Y%m%d"))).width(250);
+            text(format!("{NAME} package list: v{}", date.format("%Y%m%d"))).width(250);
         let last_update_text = text(update_state.uad_list.to_string());
         let uad_lists_btn = button_primary("Update").on_press(Message::UpdateUadLists);
 
@@ -46,7 +46,7 @@ impl About {
 
         #[cfg(feature = "self-update")]
         let uad_version_text =
-            text(format!("UAD version: v{}", env!("CARGO_PKG_VERSION"))).width(250);
+            text(format!("{NAME} version: v{}", env!("CARGO_PKG_VERSION"))).width(250);
 
         #[cfg(feature = "self-update")]
         #[rustfmt::skip]

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -8,7 +8,7 @@ use crate::core::uad_lists::{
     load_debloat_lists, Opposite, PackageHashMap, PackageState, Removal, UadList, UadListState,
 };
 use crate::core::utils::{
-    export_selection, fetch_packages, open_url, ANDROID_SERIAL, EXPORT_FILE_NAME,
+    export_selection, fetch_packages, open_url, ANDROID_SERIAL, EXPORT_FILE_NAME, NAME,
 };
 use crate::gui::style;
 use crate::gui::widgets::navigation_menu::ICONS;
@@ -352,7 +352,7 @@ impl List {
     ) -> Element<Message, Theme, Renderer> {
         match &self.loading_state {
             LoadingState::DownloadingList => waiting_view(
-                "Downloading latest UAD-ng lists from GitHub. Please wait...",
+                &format!("Downloading latest {NAME} lists from GitHub. Please wait..."),
                 Some(button("No internet?").on_press(Message::LoadUadList(false))),
                 style::Text::Default,
             ),
@@ -376,7 +376,7 @@ impl List {
                 style::Text::Default,
             ),
             LoadingState::_UpdatingUad => waiting_view(
-                "Updating UAD-ng. Please wait...",
+                &format!("Updating {NAME}. Please wait..."),
                 None,
                 style::Text::Default,
             ),
@@ -578,7 +578,7 @@ impl List {
                 .center_x();
 
             let text_box = row![
-                text("Exported current selection into file.\nFile is exported in same directory where UAD-ng is located.").width(Length::Fill),
+                text(format!("Exported current selection into file.\nFile is exported in same directory where {NAME} is located.")).width(Length::Fill),
             ].padding(20);
 
             let file_row = row![text(EXPORT_FILE_NAME).style(style::Text::Commentary)].padding(20);

--- a/src/gui/views/settings.rs
+++ b/src/gui/views/settings.rs
@@ -23,7 +23,7 @@ use iced::widget::{
 use iced::{alignment, Alignment, Command, Element, Length, Renderer};
 use std::path::PathBuf;
 
-use crate::core::utils::Error;
+use crate::core::utils::{Error, NAME};
 
 #[derive(Debug, Clone)]
 pub enum PopUpModal {
@@ -536,7 +536,7 @@ impl Settings {
                 .center_x();
 
             let text_box = row![
-                text("Exported uninstalled packages into file.\nFile is exported in same directory where UAD-ng is located.").width(Length::Fill),
+                text(format!("Exported uninstalled packages into file.\nFile is exported in same directory where {NAME} is located.")).width(Length::Fill),
             ].padding(20);
 
             let file_row = row![text(format!(


### PR DESCRIPTION
Closes #598

I decided to do an opportunistic refactoring of the app name, because this cmd:
```sh
grep -ri '"[^"]*UAD-ng[^"]*"' src/
```
printed too many lines