### PR TITLE
pkg(infinix): inform about bootloop and change `removal` to `unsafe`

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -23597,8 +23597,8 @@
     "labels": []
   },
   "com.hoffnung": {
-    "description": "TPMS\nRemote Config Test. WARNING: you should DISABLE this package instead of uninstalling, because uninstalling causes screen flicker",
-    "removal": "Recommended",
+    "description": "TPMS. Remote Config Test.\n⚠️ WARNING: uninstalling might cause bootloops and screen flicker!\nhttps://xdaforums.com/t/infinix-note-10-uninstall-tpms-com-hoffnung-package-causes-bootloop.4647456",
+    "removal": "Unsafe",
     "list": "Oem",
     "dependencies": [],
     "neededBy": [],


### PR DESCRIPTION
- Updates description to warn about likely boot-loops, and adds a link as backing source.
- Previous `removal` was totally inaccurate. It should've been `Expert` as bare minimum.
- Minor formatting of desc.