### PR TITLE
fix(refresh menu): typo

### DIFF
--- a/src/gui/widgets/navigation_menu.rs
+++ b/src/gui/widgets/navigation_menu.rs
@@ -28,7 +28,7 @@ pub fn nav_menu<'a>(
     )
     .on_press(Message::RefreshButtonPressed);
 
-    let apps_refresh_tooltip = tooltip(apps_refresh_btn, "Refresh apps", tooltip::Position::Bottom)
+    let apps_refresh_tooltip = tooltip(apps_refresh_btn, "Refresh devices", tooltip::Position::Bottom)
         .style(style::Container::Tooltip)
         .gap(4);
 


### PR DESCRIPTION
![2024-09-24_20-30](https://github.com/user-attachments/assets/94722928-c370-47af-8a51-97ea7a18da93)

It should be called devices, in my opinion :-)

***
OT, FYI :-)  only 

![2024-09-24_20-19](https://github.com/user-attachments/assets/c31e5122-f792-44c8-a11f-a461d3e59fad)

![2024-09-24_20-18](https://github.com/user-attachments/assets/e014809b-b49a-423d-ad47-59bff170dd2d)
