### PR TITLE
pkg(com.mig.play.games): add Funmax package

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -918,7 +918,7 @@
     "neededBy": [],
     "labels": [],
     "removal": "Recommended"
-  }
+  },
   "com.xiaomi.market": {
     "list": "Oem",
     "description": "GetApps\nChina Mi App Store.\nI used it only to install google play.",

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -911,6 +911,14 @@
     "labels": [],
     "removal": "Recommended"
   },
+  "com.mig.play.games": {
+    "list": "Oem",
+    "description": "Funmax\nSome kind of third-party game center bundled by Xiaomi.\nHas lots of permissions by default.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  }
   "com.xiaomi.market": {
     "list": "Oem",
     "description": "GetApps\nChina Mi App Store.\nI used it only to install google play.",


### PR DESCRIPTION
Funmax is Chinese bloatware included by Xiaomi, it has lots of permissions by default, but isn't required for anything, so it can safely be removed.