### PR TITLE
chore(issue-template): add ADB version field for bug-report

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -62,6 +62,12 @@ body:
     label: Desktop Environment
     description: If relevant, please fill it
     placeholder: GNOME 46, KDE Plasma 4, etc...
+- type: input
+  id: adb-v
+  attributes:
+    label: ADB version
+    description: If relevant, please fill it
+    placeholder: 1.0.41
 - type: textarea
   id: logfiles
   attributes:


### PR DESCRIPTION
Why did we not have this earlier? 💀

BTW, since ADB typically comes bundled as part of the SDK Platform Tools, there's a **another version number**. I omitted it from the `placeholder`, because it doesn't seem necessary