### PR TITLE
pkg(samsung): improve S-location related descriptions

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -4319,7 +4319,7 @@
   },
   "com.samsung.android.location": {
     "list": "Oem",
-    "description": "Slocation.\nIt handles GPS queries for some Samsung Galaxy apps, such as Camera location tagging. Apps exclusively using raw GPS and/or Google Location API are unaffected\n",
+    "description": "Slocation.\nIt handles GPS queries for some Samsung (Galaxy) apps, such as Camera location tagging. Apps exclusively using raw GPS and/or Google Location API are unaffected\n",
     "dependencies": [],
     "neededBy": [],
     "labels": [],

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -5940,7 +5940,7 @@
   },
   "com.sec.location.nsflp2": {
     "list": "Oem",
-    "description": "Samsung Location SDK\nI just know this doesn't have any impact on GPS stuff. \nIt seems to be only used along Samsung apps.\n",
+    "description": "Samsung Location SDK\nIt seems to only be used by Samsung (Galaxy) apps",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
@@ -32301,7 +32301,7 @@
   },
   "com.samsung.locationhistory": {
     "list": "Oem",
-    "description": "it's only location logs",
+    "description": "It's only location logs",
     "dependencies": [],
     "neededBy": [],
     "labels": [],

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -4319,7 +4319,7 @@
   },
   "com.samsung.android.location": {
     "list": "Oem",
-    "description": "IMO it handles GPS needs for some Samsung apps. I have it removed on my phone and I still can use the GPS with a 3-party app.\n",
+    "description": "It handles GPS queries for some Samsung Galaxy apps, such as Camera location tagging. Apps exclusively using raw GPS and/or Google Location API are unaffected\n",
     "dependencies": [],
     "neededBy": [],
     "labels": [],

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -4319,7 +4319,7 @@
   },
   "com.samsung.android.location": {
     "list": "Oem",
-    "description": "Slocation.\nIt handles GPS queries for some Samsung (Galaxy) apps, such as Camera location tagging. Apps exclusively using raw GPS and/or Google Location API are unaffected\n",
+    "description": "Slocation.\nIt handles GPS queries for some Samsung (Galaxy) apps, such as Camera location tagging. Apps exclusively using raw GPS and/or Google Location API are unaffected\nhttps://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/issues/762#issuecomment-2567149732",
     "dependencies": [],
     "neededBy": [],
     "labels": [],

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -4319,7 +4319,7 @@
   },
   "com.samsung.android.location": {
     "list": "Oem",
-    "description": "It handles GPS queries for some Samsung Galaxy apps, such as Camera location tagging. Apps exclusively using raw GPS and/or Google Location API are unaffected\n",
+    "description": "Slocation.\nIt handles GPS queries for some Samsung Galaxy apps, such as Camera location tagging. Apps exclusively using raw GPS and/or Google Location API are unaffected\n",
     "dependencies": [],
     "neededBy": [],
     "labels": [],


### PR DESCRIPTION
- closes #762
- Updates descriptions of:
  - `com.samsung.android.location`: add breakage example and display-name.
  - `com.sec.location.nsflp2`
  - `com.samsung.locationhistory`: grammar

I want to test some Galaxy phones before merging this, to see how widespread this issue is