### PR TITLE
pkg(com.xiaomi.market): categorize it as Advanced

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -921,11 +921,11 @@
   },
   "com.xiaomi.market": {
     "list": "Oem",
-    "description": "GetApps\nChina Mi App Store.\nI used it only to install google play.",
+    "description": "GetApps\nChina Mi App Store.\nEssential for installing the Google Play Store and updating key system applications, such as the System Launcher.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   "com.miui.voiceassist": {
     "list": "Oem",


### PR DESCRIPTION
The "com.xiaomi.market" package should be categorized as Advanced:
- It enables installation of the Google Play Store.
![Screenshot_2025-01-05-10-28-35-695_com xiaomi market](https://github.com/user-attachments/assets/066cd439-d672-4716-8eb2-ca6f9594da0b)
- It facilitates updates for essential system applications, such as the System Launcher.
![Screenshot_2025-01-05-10-20-23-579_com xiaomi market](https://github.com/user-attachments/assets/56607a0a-7fe6-4688-8dbf-2eb24fb41d56)