### PR TITLE
pkg(com.android.thememanager): improve description

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -16066,7 +16066,7 @@
   },
   "com.android.thememanager": {
     "list": "Oem",
-    "description": "MIUI Themes (manager)\nXiaomi seems to love confusing package names.\nLets you select and apply themes provided by Xiaomi.\nNOTE: Disabling will break the ability to change lock-screen wallpaper.\nHas a lot trackers. Running in the background.",
+    "description": "MIUI Themes (manager)\nXiaomi seems to love confusing package names.\nLets you select and apply themes provided by Xiaomi.\nNOTE: Disabling will break the ability to change the lock-screen wallpaper and ringtones in the OEM clock app. \nHas a lot trackers. Running in the background.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -16066,7 +16066,8 @@
   },
   "com.android.thememanager": {
     "list": "Oem",
-"description": "MIUI Themes (manager)\nXiaomi seems to love confusing package names.\nLets you select and apply themes provided by Xiaomi.\nNOTE: Disabling will break the ability to change the lock-screen wallpaper and ringtones in the OEM clock app.\nHas a lot trackers. Running in the background.",    "dependencies": [],
+    "description": "MIUI Themes (manager)\nXiaomi seems to love confusing package names.\nLets you select and apply themes provided by Xiaomi.\nNOTE: Disabling will break the ability to change the lock-screen wallpaper and ringtones in the OEM clock app.\nHas a lot trackers. Running in the background.",
+    "dependencies": [],
     "neededBy": [],
     "labels": [],
     "removal": "Advanced"

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -16066,8 +16066,7 @@
   },
   "com.android.thememanager": {
     "list": "Oem",
-    "description": "MIUI Themes (manager)\nXiaomi seems to love confusing package names.\nLets you select and apply themes provided by Xiaomi.\nNOTE: Disabling will break the ability to change the lock-screen wallpaper and ringtones in the OEM clock app. \nHas a lot trackers. Running in the background.",
-    "dependencies": [],
+"description": "MIUI Themes (manager)\nXiaomi seems to love confusing package names.\nLets you select and apply themes provided by Xiaomi.\nNOTE: Disabling will break the ability to change the lock-screen wallpaper and ringtones in the OEM clock app.\nHas a lot trackers. Running in the background.",    "dependencies": [],
     "neededBy": [],
     "labels": [],
     "removal": "Advanced"


### PR DESCRIPTION
Hello,

as stated in the commit itself, removing this package also breaks the selection of ring tones. I also suspect that it may break ringtones all together and force the alarm to always be silent if the phone is restarted after removing it. I came to this conclusion from my brief test, the ringing did not work before restoring the package but did after I uninstalled it again, I'd consider this a pretty large issue (seeing as I almost missed school today because of it), however I have yet to confirm this. I am currently unable to test this, but I'll report with my findings as soon as I'm able to.

Just for clarity, the phone this is occurring on is a Redmi Note 13 running on MIUI 14.0.6, but I see no reason this would be a phone-specific or miui-version-specific issue.

Thank you.