### PR TITLE
build(ci): add runner for MacOS with Intel CPU

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -9,16 +9,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build_target: [linux, macos, windows]
+        build_target: [linux, macos, macos-13, windows]
         update_feature: [self-update, no-self-update]
         exclude:
           - build_target: windows
             update_feature: no-self-update
+          - build_target: macos-13
+            os: macos-latest # Avoid duplicate runs on macos-latest
         include:
           - build_target: linux
             os: ubuntu-latest
           - build_target: macos
             os: macos-latest
+          - build_target: macos-13
+            os: macos-13
           - build_target: windows
             os: windows-latest
           - update_feature: self-update
@@ -52,7 +56,7 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: tar -czf uad-ng${{ matrix.update_name }}-${{ matrix.build_target }}{.tar.gz,}
       - name: Install coreutils for macOS
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os, 'macos')
         run: brew install coreutils
       - name: Create checksums for binaries and archives [Windows]
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
This PR adds support for `macos-13`, which has an Intel CPU: https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories. Perhaps it's a good idea to version the `os` anyway.