### PR TITLE
feat(ui): clearer "All" filters

### DIFF
--- a/src/core/uad_lists.rs
+++ b/src/core/uad_lists.rs
@@ -112,7 +112,7 @@ impl std::fmt::Display for PackageState {
             f,
             "{}",
             match self {
-                Self::All => "All packages",
+                Self::All => "All states",
                 Self::Enabled => "Enabled",
                 Self::Uninstalled => "Uninstalled",
                 Self::Disabled => "Disabled",
@@ -177,7 +177,7 @@ impl std::fmt::Display for Removal {
             f,
             "{}",
             match self {
-                Self::All => "All",
+                Self::All => "All removals",
                 Self::Recommended => "Recommended",
                 Self::Advanced => "Advanced",
                 Self::Expert => "Expert",


### PR DESCRIPTION
[Quoting myself](https://discord.com/channels/1168607797081022514/1171387180409692160/1328128536715857971):
> [...] I'll also open a PR about the filters. It's bothering me that the "All"s are so ambiguous
>
> [...] It seems Iced automatically uses their `Display` implementations, so we have to edit those

**User-facing changes:**
The goal of this PR is to reduce the cognitive load of remembering filter positions, as the "All" options will now include the type of the filter (less ambiguity).

**Technical details:**
I'm afraid [editing `impl Display`s could cause serialization bugs](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/issues/383#issuecomment-2581212023). However, [`Display` is not intended for serialization](https://doc.rust-lang.org/std/fmt/trait.Display.html) anyways, so any bugs should be fixed by implementing [`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html). [`Debug` is unstable](https://doc.rust-lang.org/std/fmt/trait.Debug.html#stability) so it can't be relied upon