### PR TITLE
feat(ADB): retry `adb devices` only 3 times in debug builds

### DIFF
--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -315,7 +315,7 @@ pub fn get_user_list() -> Vec<User> {
 // getprop ro.serialno
 pub async fn get_devices_list() -> Vec<Phone> {
     retry(
-        Fixed::from_millis(500).take(120),
+        Fixed::from_millis(500).take(if cfg!(debug_assertions) { 3 } else { 120 }),
         || match adb_shell_command(false, "devices") {
             Ok(devices) => {
                 let mut device_list: Vec<Phone> = vec![];


### PR DESCRIPTION
This reduces the need to connect a device just to test the UI. One could argue "this is bad, because you have to test the full UI, including the pack list", but that isn't always the case. We can use the "sync icon" button to manually retry the command anyways, so why be forced to wait 60s?