### PR TITLE
refactor(deps): replace `static_init` by `LazyLock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,34 +3246,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "static_init"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2a1c578e98c1c16fc3b8ec1328f7659a500737d7a0c6d625e73e830ff9c1f6"
-dependencies = [
- "bitflags 1.3.2",
- "cfg_aliases 0.1.1",
- "libc",
- "parking_lot 0.11.2",
- "parking_lot_core 0.8.6",
- "static_init_macro",
- "winapi",
-]
-
-[[package]]
-name = "static_init_macro"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a2595fc3aa78f2d0e45dd425b22282dd863273761cc77780914b2cf3003acf"
-dependencies = [
- "cfg_aliases 0.1.1",
- "memchr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3568,7 +3540,6 @@ dependencies = [
  "rfd",
  "serde",
  "serde_json",
- "static_init",
  "tar",
  "toml",
  "ureq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ no-self-update = []
 dark-light = "2"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
-static_init = "^1.0"
 fern = { version = "^0", features = ["colored"] }
 chrono = { version = "^0.4", default-features = false, features = [
   "std",

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -99,10 +99,11 @@ impl Config {
     }
 }
 
-//write unit tests:
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, reason = "")]
 #[cfg(test)]
 mod tests {
+    //! Unit tests
+
     use super::*;
     use std::path::Path;
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -7,9 +7,9 @@ use crate::gui::views::settings::Settings;
 use crate::CACHE_DIR;
 use crate::CONFIG_DIR;
 use serde::{Deserialize, Serialize};
-use static_init::dynamic;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
 pub struct Config {
@@ -64,8 +64,7 @@ impl Default for DeviceSettings {
     }
 }
 
-#[dynamic]
-static CONFIG_FILE: PathBuf = CONFIG_DIR.join("config.toml");
+static CONFIG_FILE: LazyLock<PathBuf> = LazyLock::new(|| CONFIG_DIR.join("config.toml"));
 
 impl Config {
     pub fn save_changes(settings: &Settings, device_id: &String) {

--- a/src/core/save.rs
+++ b/src/core/save.rs
@@ -4,12 +4,13 @@ use crate::core::utils::DisplayablePath;
 use crate::gui::widgets::package_row::PackageRow;
 use crate::CACHE_DIR;
 use serde::{Deserialize, Serialize};
-use static_init::dynamic;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
-#[dynamic]
-pub static BACKUP_DIR: PathBuf = CACHE_DIR.join("backups");
+pub static BACKUP_DIR: LazyLock<PathBuf> = LazyLock::new(|| CACHE_DIR.join("backups"));
 
 #[derive(Default, Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct PhoneBackup {

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -5,16 +5,16 @@ use crate::gui::widgets::package_row::PackageRow;
 use regex::Regex;
 use retry::{delay::Fixed, retry, OperationResult};
 use serde::{Deserialize, Serialize};
-use static_init::dynamic;
 use std::collections::HashSet;
 use std::env;
 use std::process::Command;
+use std::sync::LazyLock;
 
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
 
-#[dynamic]
-static RE: Regex = Regex::new(r"\n(\S+)\s+device").unwrap();
+static RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\n(\S+)\s+device").unwrap_or_else(|_| unreachable!()));
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Phone {
@@ -296,8 +296,8 @@ pub fn is_protected_user(user_id: &str) -> bool {
 }
 
 pub fn get_user_list() -> Vec<User> {
-    #[dynamic]
-    static RE: Regex = Regex::new(r"\{([0-9]+)").unwrap();
+    static RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\{([0-9]+)").unwrap_or_else(|_| unreachable!()));
     adb_shell_command(true, "pm list users")
         .map(|users| {
             RE.find_iter(&users)

--- a/src/core/theme.rs
+++ b/src/core/theme.rs
@@ -1,6 +1,6 @@
 use dark_light;
 use iced::{color, Color};
-use static_init::dynamic;
+use std::sync::LazyLock;
 
 /*
 In-memory caching.
@@ -11,9 +11,8 @@ Coincidentally, this also ensures consistent colors across the GUI,
 at the cost of requiring a restart to update the palette.
 (this is just a patch, not a fix)
 */
-#[dynamic(lazy)]
-pub static OS_COLOR_SCHEME: dark_light::Mode =
-    dark_light::detect().unwrap_or(dark_light::Mode::Unspecified);
+pub static OS_COLOR_SCHEME: LazyLock<dark_light::Mode> =
+    LazyLock::new(|| dark_light::detect().unwrap_or(dark_light::Mode::Unspecified));
 
 #[derive(Default, Debug, PartialEq, Eq, Copy, Clone)]
 /// Color scheme

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,18 +8,16 @@ use fern::{
     FormatCallback,
 };
 use log::Record;
-use static_init::dynamic;
-use std::path::PathBuf;
-use std::{fmt::Arguments, fs::OpenOptions};
+use std::sync::LazyLock;
+use std::{fmt::Arguments, fs::OpenOptions, path::PathBuf};
 
 mod core;
 mod gui;
 
-#[dynamic]
-static CONFIG_DIR: PathBuf = setup_uad_dir(&dirs::config_dir().expect("Can't detect config dir"));
-
-#[dynamic]
-static CACHE_DIR: PathBuf = setup_uad_dir(&dirs::cache_dir().expect("Can't detect cache dir"));
+static CONFIG_DIR: LazyLock<PathBuf> =
+    LazyLock::new(|| setup_uad_dir(&dirs::config_dir().expect("Can't detect config dir")));
+static CACHE_DIR: LazyLock<PathBuf> =
+    LazyLock::new(|| setup_uad_dir(&dirs::cache_dir().expect("Can't detect cache dir")));
 
 fn main() -> iced::Result {
     setup_logger().expect("setup logging");


### PR DESCRIPTION
- closes #756
- `config.rs` tests: Converts a comment to a module-level comment. Silences `unwrap_used` warning
- Merge some `use` imports, because `rustfmt` was re-ordering them, and to reduce redundancy