### PR TITLE
pkg(com.android.intentresolver): improve description and change removal

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -7348,11 +7348,11 @@
   },
   "com.android.intentresolver": {
     "list": "Aosp",
-    "description": "In Android 14 they moved the share menu into this package; if you uninstall it, you can no longer use it. Uh, also breaks motion photos.",
+    "description": "'Share' functionality will be disabled after uninstalling this package on Android 14 and up. Additionally, motion photos will become broken.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Advanced"
+    "removal": "Expert"
   },
   "com.android.internal.display.cutout.emulation.corner": {
     "list": "Aosp",


### PR DESCRIPTION
Share is a very important part of the core OS that hardly anyone would wish to disable. Updated the description to bring attention to the word Share and moved the package from "Advanced" to "Expert".