### PR TITLE
fix: force `wgpu` to use dedicated/discrete graphics-card, to avoid Vulkan issues

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,13 @@ static CACHE_DIR: LazyLock<PathBuf> =
     LazyLock::new(|| setup_uad_dir(&dirs::cache_dir().expect("Can't detect cache dir")));
 
 fn main() -> iced::Result {
+    // Safety: This function is safe to call in a single-threaded program.
+    // The exact requirement is: you must ensure that there are no other threads concurrently writing or
+    // reading(!) the environment through functions or global variables other than the ones in this module.
+    unsafe {
+        std::env::set_var("WGPU_BACKEND", "gl");
+    }
+
     setup_logger().expect("setup logging");
     gui::UadGui::start()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,9 @@ fn main() -> iced::Result {
     // The exact requirement is: you must ensure that there are no other threads concurrently writing or
     // reading(!) the environment through functions or global variables other than the ones in this module.
     unsafe {
-        std::env::set_var("WGPU_BACKEND", "gl");
+        // Force WGPU/Iced to use discrete GPU to prevent crashes on PCs with two GPUs.
+        // See #848 and related pull 850.
+        std::env::set_var("WGPU_POWER_PREF", "high");
     }
 
     setup_logger().expect("setup logging");


### PR DESCRIPTION
I've spent like an hour looking through Iced, and apparently there is no option to pass config to wgpu, it always picks settings from env:

https://docs.rs/iced_renderer/0.12.1/src/iced_renderer/compositor.rs.html#252
https://docs.rs/iced_wgpu/0.12.1/src/iced_wgpu/settings.rs.html#47

Also, for some reason, on my PC setting via WGPU_BACKEND=gl (either in terminal or using set_env) only fixes the issue when compiling with `--release`.

fixes #848 