### PR TITLE
fix: disable debug validation of pack-IDs

### DIFF
--- a/src/core/adb.rs
+++ b/src/core/adb.rs
@@ -268,8 +268,8 @@ impl PmCommand {
                     debug_assert!(p_ln.starts_with(PACK_PREFIX));
                     let p_id = &p_ln[PACK_PREFIX.len()..];
 
-                    #[cfg(debug_assertions)]
-                    PackageId::new(p_id).expect(INVALID_PKG_ID);
+                    //#[cfg(debug_assertions)]
+                    //PackageId::new(p_id).expect(INVALID_PKG_ID);
 
                     String::from(p_id)
                 })


### PR DESCRIPTION
https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/issues/851#issuecomment-2665850695
