### PR TITLE
build(ci): version-pin OS of runners

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -16,13 +16,13 @@ jobs:
             update_feature: no-self-update
         include:
           - build_target: linux
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - build_target: macos
-            os: macos-latest
+            os: macos-14
           - build_target: macos-intel
             os: macos-13
           - build_target: windows
-            os: windows-latest
+            os: windows-2022
           - update_feature: self-update
             update_name: "" # we don't want this in the binary filename
           - update_feature: no-self-update
@@ -41,26 +41,26 @@ jobs:
             target
           key: ${{ runner.os }}-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.OS }}-release-
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
       - name: Building
         run: cargo build --release --no-default-features --features wgpu,${{ matrix.update_feature }}
       - name: Renaming binaries [Windows]
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         run: mv target/release/uad-ng.exe uad-ng-${{ matrix.build_target }}.exe
       - name: Renaming binaries [Others]
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-2022'
         run: mv target/release/uad-ng uad-ng${{ matrix.update_name }}-${{ matrix.build_target }}
       - name: Tarball Linux/MacOS binary
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-2022'
         run: tar -czf uad-ng${{ matrix.update_name }}-${{ matrix.build_target }}{.tar.gz,}
       - name: Install coreutils for macOS
         if: startsWith(matrix.os, 'macos')
         run: brew install coreutils
       - name: Create checksums for binaries and archives [Windows]
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2022'
         run: sha256sum uad-ng-${{ matrix.build_target }}.exe | tee uad-ng-${{ matrix.build_target }}.exe-checksum.txt
       - name: Create checksums for binaries and archives [Others]
-        if: matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-2022'
         run: |
           sha256sum uad-ng${{ matrix.update_name }}-${{ matrix.build_target }} | tee uad-ng${{ matrix.update_name }}-${{ matrix.build_target }}-checksum
           sha256sum uad-ng${{ matrix.update_name }}-${{ matrix.build_target }}.tar.gz | tee uad-ng${{ matrix.update_name }}-${{ matrix.build_target }}.tar.gz-checksum

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-22.04, windows-2022, macOS-14]
         lint: [check, test, clippy, fmt]
         exclude: # https://github.com/community/community/discussions/7835
-          - os: windows-latest
+          - os: windows-2022
             lint: clippy
-          - os: windows-latest
+          - os: windows-2022
             lint: fmt
-          - os: macOS-latest
+          - os: macOS-14
             lint: clippy
-          - os: macOS-latest
+          - os: macOS-14
             lint: fmt
         include:
           - lint: check
@@ -61,7 +61,7 @@ jobs:
 
   coverage:
     name: coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Downloads artifacts
         uses: actions/download-artifact@v4
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: uad-ng-*/*
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     uses: ./.github/workflows/build_artifacts.yml
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     permissions:
       contents: write


### PR DESCRIPTION
This PR also upgrades the [GitHub release Action to v2](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/commit/60c89c887c2134733f68e82a876959a1db610802).

Artifact build results: https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/actions/runs/13401871180