### PR TITLE
fix: use advanced text shaping to prevent text being rendered as squares with certain fonts or CJK characters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,5 +73,8 @@ shadow_unrelated = "warn"
 struct_field_names = "allow" # annoying
 module_name_repetitions = "allow" # annoying
 
+disallowed_types = "deny"
+disallowed_methods = "deny"
+
 allow_attributes_without_reason = "warn"
 pedantic = { level = "warn", priority = -1 }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,7 @@
+disallowed-types = [
+    { path = "iced::widget::Text", reason = "with some fonts text renders as squares without advanced shaping (see #523), instead use [`crate::gui::widgets::text`]" },
+]
+
+disallowed-methods= [
+    { path = "iced::widget::text", reason = "with some fonts text renders as squares without advanced shaping (see #523), instead use [`crate::gui::widgets::text`]" },
+]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,7 @@
 disallowed-types = [
-    { path = "iced::widget::Text", reason = "with some fonts text renders as squares without advanced shaping (see #523), instead use [`crate::gui::widgets::text`]" },
+    { path = "iced::widget::Text", reason = "Use [`crate::gui::widgets::text`] instead. For further details, see #523 and #858" },
 ]
 
 disallowed-methods= [
-    { path = "iced::widget::text", reason = "with some fonts text renders as squares without advanced shaping (see #523), instead use [`crate::gui::widgets::text`]" },
+    { path = "iced::widget::text", reason = "Use [`crate::gui::widgets::text`] instead. For further details, see #523 and #858" },
 ]

--- a/src/core/uad_lists.rs
+++ b/src/core/uad_lists.rs
@@ -90,7 +90,7 @@ impl UadList {
 
 impl std::fmt::Display for UadList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_str())
+        f.write_str(self.as_str())
     }
 }
 
@@ -191,7 +191,7 @@ impl Removal {
 
 impl std::fmt::Display for Removal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_str())
+        f.write_str(self.as_str())
     }
 }
 

--- a/src/core/uad_lists.rs
+++ b/src/core/uad_lists.rs
@@ -3,6 +3,7 @@ use crate::CACHE_DIR;
 use retry::{delay::Fixed, retry, OperationResult};
 use serde::{Deserialize, Serialize};
 use serde_json;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -72,24 +73,30 @@ impl UadList {
         Self::Pending,
         Self::Unlisted,
     ];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::All => "All lists",
+            Self::Aosp => "aosp",
+            Self::Carrier => "carrier",
+            Self::Google => "google",
+            Self::Misc => "misc",
+            Self::Oem => "oem",
+            Self::Pending => "pending",
+            Self::Unlisted => "unlisted",
+        }
+    }
 }
 
 impl std::fmt::Display for UadList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::All => "All lists",
-                Self::Aosp => "aosp",
-                Self::Carrier => "carrier",
-                Self::Google => "google",
-                Self::Misc => "misc",
-                Self::Oem => "oem",
-                Self::Pending => "pending",
-                Self::Unlisted => "unlisted",
-            }
-        )
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl From<UadList> for Cow<'_, str> {
+    fn from(list: UadList) -> Self {
+        Cow::Borrowed(list.as_str())
     }
 }
 
@@ -169,22 +176,28 @@ impl Removal {
         Self::Unsafe,
         Self::Unlisted,
     ];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::All => "All removals",
+            Self::Recommended => "Recommended",
+            Self::Advanced => "Advanced",
+            Self::Expert => "Expert",
+            Self::Unsafe => "Unsafe",
+            Self::Unlisted => "Unlisted",
+        }
+    }
 }
 
 impl std::fmt::Display for Removal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::All => "All removals",
-                Self::Recommended => "Recommended",
-                Self::Advanced => "Advanced",
-                Self::Expert => "Expert",
-                Self::Unsafe => "Unsafe",
-                Self::Unlisted => "Unlisted",
-            }
-        )
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl From<Removal> for Cow<'_, str> {
+    fn from(list: Removal) -> Self {
+        Cow::Borrowed(list.as_str())
     }
 }
 

--- a/src/gui/views/about.rs
+++ b/src/gui/views/about.rs
@@ -2,9 +2,9 @@ use crate::core::helpers::button_primary;
 use crate::core::theme::Theme;
 use crate::core::uad_lists::LIST_FNAME;
 use crate::core::utils::{last_modified_date, open_url, NAME};
-use crate::gui::{style, UpdateState};
+use crate::gui::{style, widgets::text, UpdateState};
 use crate::CACHE_DIR;
-use iced::widget::{column, container, row, text, Space};
+use iced::widget::{column, container, row, Space};
 use iced::{Alignment, Element, Length, Renderer};
 use std::path::PathBuf;
 

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -921,14 +921,14 @@ fn error_view<'a>(
 }
 
 fn waiting_view<'a>(
-    displayed_text: &str,
+    displayed_text: &(impl ToString + ?Sized),
     btn: Option<button::Button<'a, Message, Theme, Renderer>>,
     text_style: style::Text,
 ) -> Element<'a, Message, Theme, Renderer> {
     let col = column![]
         .spacing(10)
         .align_items(Alignment::Center)
-        .push(text(displayed_text).style(text_style).size(20));
+        .push(text(displayed_text.to_string()).style(text_style).size(20));
 
     let col = match btn {
         Some(btn) => col.push(btn.style(style::Button::Primary).padding([5, 10])),
@@ -1004,7 +1004,7 @@ fn recap<'a>(settings: &Settings, recap: &SummaryEntry) -> Element<'a, Message, 
                     text("Uninstall").style(style::Text::Danger)
                 },
                 horizontal_space(),
-                text(recap.discard).style(style::Text::Danger)
+                text(recap.discard.to_string()).style(style::Text::Danger)
             ]
             .width(Length::FillPortion(1)),
             vertical_rule(5),
@@ -1015,7 +1015,7 @@ fn recap<'a>(settings: &Settings, recap: &SummaryEntry) -> Element<'a, Message, 
                     text("Restore").style(style::Text::Ok)
                 },
                 horizontal_space(),
-                text(recap.restore).style(style::Text::Ok)
+                text(recap.restore.to_string()).style(style::Text::Ok)
             ]
             .width(Length::FillPortion(1))
         ]

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -15,8 +15,9 @@ use std::path::PathBuf;
 use crate::gui::views::settings::Settings;
 use crate::gui::widgets::modal::Modal;
 use crate::gui::widgets::package_row::{Message as RowMessage, PackageRow};
+use crate::gui::widgets::text;
 use iced::widget::{
-    button, checkbox, column, container, horizontal_space, pick_list, radio, row, scrollable, text,
+    button, checkbox, column, container, horizontal_space, pick_list, radio, row, scrollable,
     text_input, tooltip, vertical_rule, Column, Space,
 };
 use iced::{alignment, Alignment, Command, Element, Length, Renderer};

--- a/src/gui/views/settings.rs
+++ b/src/gui/views/settings.rs
@@ -17,10 +17,9 @@ use crate::gui::{
     widgets::modal::Modal,
     widgets::navigation_menu::ICONS,
     widgets::package_row::PackageRow,
+    widgets::text,
 };
-use iced::widget::{
-    button, checkbox, column, container, pick_list, radio, row, scrollable, text, Space, Text,
-};
+use iced::widget::{button, checkbox, column, container, pick_list, radio, row, scrollable, Space};
 use iced::{alignment, Alignment, Element, Length, Renderer};
 use std::path::PathBuf;
 
@@ -297,7 +296,7 @@ impl Settings {
         let choose_backup_descr = text("Note: If you have previous backups, you will need to transfer them manually to newly changed backup folder to be able to use Restore functionality")
             .style(style::Text::Commentary);
 
-        let choose_backup_btn = button(Text::new("\u{E930}").font(ICONS))
+        let choose_backup_btn = button(text("\u{E930}").font(ICONS))
             .padding([5, 10])
             .on_press(Message::ChooseBackUpFolder)
             .style(style::Button::Primary);
@@ -307,7 +306,7 @@ impl Settings {
             "Choose backup folder",
             Space::new(Length::Fill, Length::Shrink),
             "Current folder: ",
-            Text::new(self.general.backup_folder.to_string_lossy())
+            text(self.general.backup_folder.to_string_lossy())
         ]
         .spacing(10)
         .align_items(Alignment::Center);

--- a/src/gui/widgets/mod.rs
+++ b/src/gui/widgets/mod.rs
@@ -1,3 +1,6 @@
 pub mod modal;
 pub mod navigation_menu;
 pub mod package_row;
+
+mod text;
+pub use text::text;

--- a/src/gui/widgets/navigation_menu.rs
+++ b/src/gui/widgets/navigation_menu.rs
@@ -4,8 +4,8 @@ use crate::core::theme::Theme;
 use crate::core::update::{SelfUpdateState, SelfUpdateStatus};
 pub use crate::gui::views::about::Message as AboutMessage;
 pub use crate::gui::views::list::{List as AppsView, LoadingState as ListLoadingState};
-use crate::gui::{style, Message};
-use iced::widget::{button, container, pick_list, row, text, tooltip, Space, Text};
+use crate::gui::{style, widgets::text, Message};
+use iced::widget::{button, container, pick_list, row, tooltip, Space};
 use iced::{alignment, font, Alignment, Element, Font, Length, Renderer};
 
 /// resources/assets/icons.ttf, loaded in [`crate::gui::UadGui`]
@@ -21,7 +21,7 @@ pub fn nav_menu<'a>(
     self_update_state: &SelfUpdateState,
 ) -> Element<'a, Message, Theme, Renderer> {
     let apps_refresh_btn = button_primary(
-        Text::new("\u{E900}")
+        text("\u{E900}")
             .font(ICONS)
             .width(22)
             .horizontal_alignment(alignment::Horizontal::Center),
@@ -37,17 +37,17 @@ pub fn nav_menu<'a>(
     #[allow(clippy::option_if_let_else)]
     let uad_version_text = if let Some(r) = &self_update_state.latest_release {
         match self_update_state.status {
-            SelfUpdateStatus::Failed => Text::new(format!("Failed to update to {}", r.tag_name)),
-            SelfUpdateStatus::Checking => Text::new(SelfUpdateStatus::Checking.to_string()),
-            SelfUpdateStatus::Done => Text::new(format!(
+            SelfUpdateStatus::Failed => text(format!("Failed to update to {}", r.tag_name)),
+            SelfUpdateStatus::Checking => text(SelfUpdateStatus::Checking.to_string()),
+            SelfUpdateStatus::Done => text(format!(
                 "Update available: {} -> {}",
                 env!("CARGO_PKG_VERSION"),
                 r.tag_name
             )),
-            SelfUpdateStatus::Updating => Text::new("Updating please wait..."),
+            SelfUpdateStatus::Updating => text("Updating please wait..."),
         }
     } else {
-        Text::new(format!("v{}", env!("CARGO_PKG_VERSION")))
+        text(format!("v{}", env!("CARGO_PKG_VERSION")))
     };
 
     let update_btn = if self_update_state.latest_release.is_some() {
@@ -64,7 +64,7 @@ pub fn nav_menu<'a>(
     let about_btn = button_primary("About").on_press(Message::AboutPressed);
 
     let settings_btn = button_primary(
-        Text::new("\u{E994}")
+        text("\u{E994}")
             .font(ICONS)
             .width(22)
             .horizontal_alignment(alignment::Horizontal::Center),

--- a/src/gui/widgets/package_row.rs
+++ b/src/gui/widgets/package_row.rs
@@ -3,8 +3,9 @@ use crate::core::theme::Theme;
 use crate::core::uad_lists::{PackageState, Removal, UadList};
 use crate::gui::style;
 use crate::gui::views::settings::Settings;
+use crate::gui::widgets::text;
 
-use iced::widget::{button, checkbox, row, text, Space};
+use iced::widget::{button, checkbox, row, Space};
 use iced::{alignment, Alignment, Command, Element, Length, Renderer};
 
 #[derive(Clone, Debug)]

--- a/src/gui/widgets/text.rs
+++ b/src/gui/widgets/text.rs
@@ -1,0 +1,15 @@
+#![allow(
+    clippy::disallowed_types,
+    reason = "this is the replacement that enforces advanced shaping for disallowed [`iced::widget::Text`]"
+)]
+
+use iced::widget::Text;
+
+// Creates a new Text widget with advanced shaping.
+pub fn text<'a, Theme, Renderer>(text: impl ToString) -> Text<'a, Theme, Renderer>
+where
+    Theme: iced::widget::text::StyleSheet,
+    Renderer: iced::advanced::text::Renderer,
+{
+    Text::new(text.to_string()).shaping(iced::widget::text::Shaping::Advanced)
+}

--- a/src/gui/widgets/text.rs
+++ b/src/gui/widgets/text.rs
@@ -3,13 +3,15 @@
     reason = "this is the replacement that enforces advanced shaping for disallowed [`iced::widget::Text`]"
 )]
 
+use std::borrow::Cow;
+
 use iced::widget::Text;
 
 // Creates a new Text widget with advanced shaping.
-pub fn text<'a, Theme, Renderer>(text: impl ToString) -> Text<'a, Theme, Renderer>
+pub fn text<'a, Theme, Renderer>(text: impl Into<Cow<'a, str>>) -> Text<'a, Theme, Renderer>
 where
     Theme: iced::widget::text::StyleSheet,
     Renderer: iced::advanced::text::Renderer,
 {
-    Text::new(text.to_string()).shaping(iced::widget::text::Shaping::Advanced)
+    Text::new(text).shaping(iced::widget::text::Shaping::Advanced)
 }


### PR DESCRIPTION
I was only able to reproduce #523 with CJK characters. I tried using default Pop!_OS fonts from their PPA, but they were rendering normally.

This fix is based on the following comments:
- https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/issues/523#issue-2378550768 the input field is rendered properly.
- https://github.com/iced-rs/iced/issues/2709 again, the input field is rendered properly, and the user notes "Adding shaping(text::Shaping::Advanced) makes the text render properly.".

fixes: #523