### PR TITLE
chore(issue-template): add CI issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/7-ci.yml
+++ b/.github/ISSUE_TEMPLATE/7-ci.yml
@@ -1,0 +1,38 @@
+name: CI/CD
+description: File a feature request or bug-report for CI/CD
+title: "ci(scope): "
+labels: ["ci"]
+body:
+- type: textarea
+  attributes:
+    label: Expected feature
+    description: A clear and concise description of what the problem is and how it could be approached.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Alternative solutions
+    description: A clear and concise description of any alternative solutions or features you've considered.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false
+- type: checkboxes
+  id: acknowledgements
+  attributes:
+    label: Acknowledgements
+    description: Your bug report will be closed if you don't follow the checklist below.
+    options:
+      - label: This issue is not a duplicate of an existing bug report.
+        required: true
+      - label: I have chosen an appropriate title.
+        required: true
+      - label: All requested information has been provided properly.
+        required: true

--- a/.github/ISSUE_TEMPLATE/7-ci.yml
+++ b/.github/ISSUE_TEMPLATE/7-ci.yml
@@ -1,17 +1,17 @@
 name: CI/CD
-description: File a feature request or bug-report for CI/CD
+description: File an issue for CI/CD
 title: "ci(scope): "
 labels: ["ci"]
 body:
 - type: textarea
   attributes:
-    label: Expected feature
+    label: Expected behavior
     description: A clear and concise description of what the problem is and how it could be approached.
   validations:
     required: true
 - type: textarea
   attributes:
-    label: Alternative solutions
+    label: Alternate solutions
     description: A clear and concise description of any alternative solutions or features you've considered.
   validations:
     required: false
@@ -28,9 +28,9 @@ body:
   id: acknowledgements
   attributes:
     label: Acknowledgements
-    description: Your bug report will be closed if you don't follow the checklist below.
+    description: Your issue will be closed if you don't follow the checklist below.
     options:
-      - label: This issue is not a duplicate of an existing bug report.
+      - label: This issue is not a duplicate of an existing issue.
         required: true
       - label: I have chosen an appropriate title.
         required: true

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,14 +6,18 @@ changelog:
     - title: Fixed
       labels:
         - bug
-    - title: Miscellaneous
+    - title: Refactors
       labels:
         - refactor
-        - dependencies
-        - documentation
-        - ci
     - title: Packages/apps
       labels:
-      - package::documentation
-      - package::addition
-      - package::breakage
+        - package::documentation
+        - package::addition
+        - package::breakage
+    - title: Development
+      labels:
+        - ci
+        - dependencies
+    - title: Documentation
+      labels:
+        - documentation

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -11,7 +11,7 @@ changelog:
         - refactor
         - dependencies
         - documentation
-        - testing
+        - ci
     - title: Packages/apps
       labels:
       - package::documentation


### PR DESCRIPTION
- [chore(release): rename testing to ci](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/commit/cf03839ac78199621eb36b4e1d10e22c15b1a272)
- [chore(issue-template): add CI issue template](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/commit/aa6bd2417ad2be7d4c292bc2b3ee43417a52cecf)
- [ci(changelog): add and rename titles](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/883/commits/f7d77819c1d511513957a7384d9c4ea44607f483)