### PR TITLE
feat(GUI:view:about): show `adb version`

### DIFF
--- a/src/core/adb.rs
+++ b/src/core/adb.rs
@@ -131,7 +131,7 @@ impl ACommand {
             cmd.get_args()
                 .map(|s| s.to_str().unwrap_or_else(|| unreachable!()))
                 .collect::<Vec<_>>()
-                .join("' '")
+                .join(" ")
         );
         match cmd.output() {
             Err(e) => {

--- a/src/core/adb.rs
+++ b/src/core/adb.rs
@@ -117,7 +117,7 @@ impl ACommand {
     /// ## Format
     /// This is just a sample,
     /// we don't know which guarantees are stable (yet):
-    /// ```
+    /// ```txt
     /// Android Debug Bridge version 1.0.41
     /// Version 34.0.5-debian
     /// Installed as /usr/lib/android-sdk/platform-tools/adb
@@ -125,7 +125,7 @@ impl ACommand {
     /// ```
     ///
     /// The expected format should be like:
-    /// ```
+    /// ```txt
     /// Android Debug Bridge version <num>.<num>.<num>
     /// Version <num>.<num>.<num>-<no spaces>
     /// Installed as <ANDROID_SDK_HOME>/platform-tools/adb<optional extension>

--- a/src/core/adb.rs
+++ b/src/core/adb.rs
@@ -63,12 +63,15 @@ pub fn to_trimmed_utf8(v: Vec<u8>) -> String {
 pub struct ACommand(std::process::Command);
 impl ACommand {
     /// `adb` command builder
+    #[must_use]
     pub fn new() -> Self {
         Self(std::process::Command::new("adb"))
     }
+
     /// `shell` sub-command builder.
     ///
     /// If `device_serial` is empty, it lets ADB choose the default device.
+    #[must_use]
     pub fn shell<S: AsRef<str>>(mut self, device_serial: S) -> ShellCommand {
         let serial = device_serial.as_ref();
         if !serial.is_empty() {
@@ -77,6 +80,7 @@ impl ACommand {
         self.0.arg("shell");
         ShellCommand(self)
     }
+
     /// Header-less list of attached devices (as serials) and their statuses:
     /// - USB
     /// - TCP/IP: WIFI, Ethernet, etc...
@@ -107,6 +111,15 @@ impl ACommand {
             })
             .collect())
     }
+
+    /// `version` sub-command, splitted by lines
+    pub fn version(mut self) -> Result<Vec<String>, String> {
+        self.0.arg("version");
+        // typically 5 allocs (after `lines`).
+        // ideally 0, if we didn't use `lines`.
+        Ok(self.run()?.lines().map(str::to_string).collect())
+    }
+
     /// General executor
     fn run(self) -> Result<String, String> {
         let mut cmd = self.0;

--- a/src/core/adb.rs
+++ b/src/core/adb.rs
@@ -143,12 +143,12 @@ impl ACommand {
         });
 
         self.0.arg("version");
-        // typically 5 allocs (after `lines`).
-        // ideally 0, if we didn't use `lines`.
         Ok(self
             .run()?
             .lines()
             .enumerate()
+            // typically 5 allocs.
+            // ideally 0, if we didn't use `lines`.
             .map(|(i, ln)| {
                 debug_assert!(match i {
                     0 => TRIPLE.is_match(ln),

--- a/src/core/adb.rs
+++ b/src/core/adb.rs
@@ -113,6 +113,24 @@ impl ACommand {
     }
 
     /// `version` sub-command, splitted by lines
+    ///
+    /// ## Format
+    /// This is just a sample,
+    /// we don't know which guarantees are stable (yet):
+    /// ```
+    /// Android Debug Bridge version 1.0.41
+    /// Version 34.0.5-debian
+    /// Installed as /usr/lib/android-sdk/platform-tools/adb
+    /// Running on Linux 6.12.12-amd64 (x86_64)
+    /// ```
+    ///
+    /// The expected format should be like:
+    /// ```
+    /// Android Debug Bridge version <num>.<num>.<num>
+    /// Version <num>.<num>.<num>-<no spaces>
+    /// Installed as <ANDROID_SDK_HOME>/platform-tools/adb<optional extension>
+    /// Running on <OS/kernel version> (<CPU arch>)
+    /// ```
     pub fn version(mut self) -> Result<Vec<String>, String> {
         self.0.arg("version");
         // typically 5 allocs (after `lines`).


### PR DESCRIPTION
- Closes #893
- Fixes a log formatting bug that should've been fixed [here](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/880/commits/1d657e899e66f758f034e3a10161bd3adac4ed81)
- Adds some `must_use` attributes to ADB methods