### PR TITLE
hotfix(self-update): differentiate between Intel and Apple Silicon on MacOS and update Windows binary name

### DIFF
--- a/src/core/update.rs
+++ b/src/core/update.rs
@@ -243,7 +243,7 @@ pub const fn bin_name() -> &'static str {
         "uad-ng-macos-intel"
     }
 
-    #[cfg(all(target_os = "macos", target_arch = "arm"))]
+    #[cfg(all(target_os = "macos", any(target_arch = "arm", target_arch = "aarch64")))]
     {
         "uad-ng-macos"
     }

--- a/src/core/update.rs
+++ b/src/core/update.rs
@@ -238,7 +238,12 @@ pub const fn bin_name() -> &'static str {
         "uad-ng.exe"
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(all(target_os = "macos",target_arch="x86_64"))]
+    {
+        "uad-ng-macos-intel"
+    }
+
+    #[cfg(all(target_os = "macos",target_arch="arm"))]
     {
         "uad-ng-macos"
     }

--- a/src/core/update.rs
+++ b/src/core/update.rs
@@ -238,12 +238,12 @@ pub const fn bin_name() -> &'static str {
         "uad-ng.exe"
     }
 
-    #[cfg(all(target_os = "macos",target_arch="x86_64"))]
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
     {
         "uad-ng-macos-intel"
     }
 
-    #[cfg(all(target_os = "macos",target_arch="arm"))]
+    #[cfg(all(target_os = "macos", target_arch = "arm"))]
     {
         "uad-ng-macos"
     }

--- a/src/core/update.rs
+++ b/src/core/update.rs
@@ -238,7 +238,7 @@ pub const fn bin_name() -> &'static str {
         "uad-ng.exe"
     }
 
-    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    #[cfg(all(target_os = "macos", any(target_arch = "x86_64", target_arch = "x86")))]
     {
         "uad-ng-macos-intel"
     }

--- a/src/core/update.rs
+++ b/src/core/update.rs
@@ -235,7 +235,7 @@ pub fn extract_binary_from_tar(archive_path: &Path, temp_file: &Path) -> io::Res
 pub const fn bin_name() -> &'static str {
     #[cfg(target_os = "windows")]
     {
-        "uad-ng.exe"
+        "uad-ng-windows.exe"
     }
 
     #[cfg(all(target_os = "macos", any(target_arch = "x86_64", target_arch = "x86")))]


### PR DESCRIPTION
Fixes #892 