### PR TITLE
chore(release): bump version to 1.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3529,7 +3529,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "uad-ng"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "chrono",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uad-ng"
 description = "A cross-platform GUI debloater for android devices"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Universal-Debloater-Alliance"]
 license = "GPL-3.0"
 homepage = "https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@ In that case, we should closely review the PR and 'compare' it with what semanti
 - [ ] Make sure the Milestone is completed and if not, check what needs to be done to complete it.
 - [ ] Make sure all merged PRs regarding the application follow the Conventional Commit Messages style. This makes sure that when generating a changelog, the changes look consistent, which in turn improves readability.
 - [ ] Make sure all merged PRs have the correct labels assigned, as the changelog is generated based on labels.
-- [ ] Create a release preparation PR that bumps the UAD-ng version in `Cargo.toml`
+- [ ] Create a release preparation PR that bumps the UAD-ng version in `Cargo.toml` and `Cargo.lock`.
 
 When all the above has been checked, you can push a tag to `main` to trigger the GitHub Action that creates a release:
 


### PR DESCRIPTION
- [chore(release): bump version to 1.1.2](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/commit/1dbaeb56d8c3b6de1af7cee8148d6666ec9e6a2b)
- [docs(release): mention that we need to update Cargo.lock](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/commit/c649a261b39c267e34ad6b0b2db9436500aed870)