### PR TITLE
pkg(com.android.chrome): update description for clarity on functionality

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -26985,7 +26985,7 @@
   },
   "com.android.chrome": {
     "list": "Google",
-    "description": "Google Chrome (https://play.google.com/store/apps/details?id=com.android.chrome)\nOccasionally runs in the background.\nNOTE: disabling or uninstalling Chrome may break functionality for creating and storing passkeys (https://fidoalliance.org/passkeys/) on your phone, so keep this enabled if you want to use that form of authentication. G Play Services can provide this functionality on some devices",
+    "description": "Google Chrome (https://play.google.com/store/apps/details?id=com.android.chrome)\nOccasionally runs in the background.\nNOTE: Disabling or uninstalling Chrome may break functionality for creating and storing passkeys (https://fidoalliance.org/passkeys/) on your phone, so keep this enabled if you want to use that form of authentication. G Play Services can provide this functionality on some devices.\nWhen Chrome is updated via the Play Store, the Trichrome Library is also updated automatically. If Chrome is disabled or removed, it may impact WebView functionality.\nThis is because Chrome, WebView, and the Trichrome Library work together as a bundle starting from Android 10 (API 29) and above.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],


### PR DESCRIPTION
Enhance the description of Google Chrome to tell about Trichrome library which is update automatically when Chrome is update.

Starting from Android 10 (API29) Google Chrome, WebView and Trichrome library work together as a bundle, uninstall Google Chrome may break WebView function.