### PR TITLE
feat(log): single log-file (`const` name)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ fn setup_logger() -> Result<(), fern::InitError> {
         .create(true)
         .append(true)
         .truncate(false)
-        .open(CACHE_DIR.join(format!("UAD_{}.log", chrono::Local::now().format("%Y%m%d"))))?;
+        .open(CACHE_DIR.join("uadng.log"))?;
 
     let file_dispatcher = fern::Dispatch::new()
         .format(make_formatter(false))


### PR DESCRIPTION
This canonicalizes the logs to be located at the same path. The reasoning for this is that the log-entries (lines) already contain date-time data, so naming the files according to the current date is redundant.

I've also taken the opportunity to append "ng" and make the name lowercase