### PR TITLE
ci(cargo): improve linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,23 +22,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, windows-2022, macOS-14]
-        lint: [check, test, clippy, fmt]
+        lint: [clippy, test, fmt]
         exclude: # https://github.com/community/community/discussions/7835
           - os: windows-2022
-            lint: clippy
-          - os: windows-2022
             lint: fmt
-          - os: macOS-14
-            lint: clippy
           - os: macOS-14
             lint: fmt
         include:
-          - lint: check
+          - lint: clippy
             args: " --all-features"
           - lint: test
             args: ""
-          - lint: clippy
-            args: " --all-features"
           - lint: fmt
             args: " -- --check"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,9 @@ jobs:
           - lint: test
             args: ""
           - lint: clippy
-            args: " --all --all-features"
+            args: " --all-features"
           - lint: fmt
-            args: " --all -- --check"
+            args: " -- --check"
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1 # faster linker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
             lint: fmt
         include:
           - lint: clippy
-            args: " --all-features"
+            args: " --all-features -- -D clippy::all -W clippy::style"
           - lint: test
             args: ""
           - lint: fmt


### PR DESCRIPTION
The `--all` flag is deprecated in favor of `--workspace` according to the docs. Either flag has no effect, since the entire workspace is 1 crate.

Ideally, we should also elevate `rustc` warns as errors by passing `RUSTFLAGS`, but I'm unsure what's the proper way to do so. See:
- [This S.O. thread](https://stackoverflow.com/questions/56870422/how-can-i-cause-compilation-to-fail-on-warnings-on-ci-and-have-extra-rustflags-s)
- Relevant issues:
	- rust-lang/cargo#14948
	- rust-lang/cargo#12739

Follow-up of: https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/582#issuecomment-2282234568