### PR TITLE
pkg(com.oplus.trafficmonitor): update description and removal

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -26672,8 +26672,8 @@
     "labels": []
   },
   "com.oplus.trafficmonitor": {
-    "description": "OnePlus Data usage\nOneplus traffic monitor (monthly data usage, etc). This app is so bloated.",
-    "removal": "Recommended",
+    "description": "OnePlus Data usage\nOneplus traffic monitor (monthly data usage, etc). If removed, the 'Data Usage' option under 'Mobile network' will not work. Also App Info screen's 'Data usage' option will disappear",
+    "removal": "Advanced",
     "list": "Oem",
     "dependencies": [],
     "neededBy": [],


### PR DESCRIPTION
I noticed the Data Usage option was gone on my oneplus phone after removing this package. I have updated the description, clarifying what it does and changed the removal level to Advanced.  Being able to block data usage for certain apps is a useful feature I think and should not be recommended.