### PR TITLE
fix(crash): index out of bounds exception

### DIFF
--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -952,7 +952,10 @@ fn build_action_pkg_commands(
 
     let mut commands = vec![];
     for u in device.user_list.iter().filter(|&&u| {
-        !u.protected && (packages[u.index][selection.1].selected || settings.multi_user_mode)
+        !u.protected 
+            && u.index < packages.len() 
+            && selection.1 < packages[u.index].len() 
+            && (packages[u.index][selection.1].selected || settings.multi_user_mode)
     }) {
         let u_pkg = &packages[u.index][selection.1];
         let wanted_state = if settings.multi_user_mode {


### PR DESCRIPTION
I was facing a crash when trying to uninstall/disable apps on my S23 Ultra, luckily the terminal logs pointed a this line and I vibe-coded the fix

Original error:

```bash
thread 'main' panicked at src\gui\views\list.rs:959:43:
index out of bounds: the len is 0 but the index is 3
stack backtrace:
   0:     0x7ff60f51d390 - <unknown>
   1:     0x7ff60f2497fa - <unknown>
   2:     0x7ff60f51ca67 - <unknown>
   3:     0x7ff60f51d1d4 - <unknown>
   4:     0x7ff60f51c6c9 - <unknown>
   5:     0x7ff60f53e09a - <unknown>
   6:     0x7ff60f53dfef - <unknown>
   7:     0x7ff60f53e77e - <unknown>
   8:     0x7ff60f86b631 - <unknown>
   9:     0x7ff60f86b603 - <unknown>
  10:     0x7ff60f20753a - <unknown>
  11:     0x7ff60f200944 - <unknown>
  12:     0x7ff60f20c762 - <unknown>
  13:     0x7ff60f18fc9f - <unknown>
  14:     0x7ff60f1d2c8f - <unknown>
  15:     0x7ff60f1d92fd - <unknown>
  16:     0x7ff60f1d9126 - <unknown>
  17:     0x7ff60f18df7d - <unknown>
  18:     0x7ff60f2159a7 - <unknown>
  19:     0x7ff60f1c0adf - <unknown>
  20:     0x7ff60f2179fa - <unknown>
  21:     0x7ff60f854704 - <unknown>
  22:     0x7ff95a1ce8d7 - BaseThreadInitThunk
  23:     0x7ff95b29c5dc - RtlUserThreadStart
```