### PR TITLE
pkg(scope): `com.sec.android.app.hwmoduletest` breaks after removing `com.samsung.android.providers.factory` on Samsung Galaxy phones

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -25765,8 +25765,8 @@
     "labels": []
   },
   "com.samsung.android.providers.factory": {
-    "description": "FactoryTestProvider\nIt's used for log or testing.",
-    "removal": "Recommended",
+    "description": "FactoryTestProvider\nDisabling breaks hwmoduletest.",
+    "removal": "Advanced",
     "list": "Oem",
     "dependencies": [],
     "neededBy": [],


### PR DESCRIPTION
Fixes #800