### PR TITLE
pkg(com.transsion.applock): change description and removal

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -23634,8 +23634,8 @@
     "labels": []
   },
   "com.transsion.applock": {
-    "description": "AppLock\nProvides the only way to hide files and lock apps when using Transsion launchers (which the Transsion devices require for certain functionality like multiapps not working with other launchers). These are the only apps that hide files and lock apps with them.",
-    "removal": "Advanced",
+    "description": "AppLock\nProvides the only way to hide files and lock apps when using Transsion launchers (which the Transsion devices require for certain functionality like multiapps not working with other launchers). These are the only apps that hide files and lock apps with them.\nRemoval breaks recents.",
+    "removal": "Expert",
     "list": "Oem",
     "dependencies": [],
     "neededBy": [],


### PR DESCRIPTION
Removal of this package broke recents for me. Only after installing it back did my recents work. I double checked. Also checked the logcat that indeed applock is linked to the recents as a provider.


Logs:

```
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: FATAL EXCEPTION: main
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: Process: com.android.quickstep, PID: 1632
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: java.lang.RuntimeException: Unable to start activity ComponentInfo{com.android.quickstep/com.android.quickstep.RecentsActivity}: java.lang.SecurityException: Failed to find provider com.transsion.applock.provider for user 0; expected to find a valid ContentProvider for this authority
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3454)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3593)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:83)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:140)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:96)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2126)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:107)
06-21 14:05:15.845  1000  1254  1310 E HistoricalRegistry: Interaction before persistence initialized
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:264)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:7684)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
06-21 14:05:23.999  1040   655  1922 E APEExtractor: getAPEInfo not ape 20483
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:980)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: Caused by: java.lang.SecurityException: Failed to find provider com.transsion.applock.provider for user 0; expected to find a valid ContentProvider for this authority
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.os.Parcel.createException(Parcel.java:2071)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.os.Parcel.readException(Parcel.java:2039)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.os.Parcel.readException(Parcel.java:1987)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.content.IContentService$Stub$Proxy.registerContentObserver(IContentService.java:1234)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.content.ContentResolver.registerContentObserver(ContentResolver.java:2263)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.content.ContentResolver.registerContentObserver(ContentResolver.java:2251)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at com.transsion.recents.b.e(Unknown Source:28)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at com.transsion.recents.b.a(Unknown Source:6)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at com.android.quickstep.r2.onCreate(Unknown Source:77)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.app.Activity.performCreate(Activity.java:7805)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.app.Activity.performCreate(Activity.java:7794)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1306)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3424)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	... 11 more
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: Caused by: android.os.RemoteException: Remote stack trace:
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at com.android.server.content.ContentService.registerContentObserver(ContentService.java:344)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.content.IContentService$Stub.onTransact(IContentService.java:482)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.os.Binder.execTransactInternal(Binder.java:1046)
06-21 14:05:26.040 10063  1632  1632 E AndroidRuntime: 	at android.os.Binder.execTransact(Binder.java:997)
```