### PR TITLE
build: split `release` profile into `opt`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,14 @@ tar = { version = "^0.4", optional = true }
 win32console = "^0.1.5"
 
 [profile.release]
+lto = "thin"
+codegen-units = 4
+
+[profile.opt]
+inherits = "release"
 opt-level = "s"
 codegen-units = 1
-lto = true
+lto = "fat"
 strip = true
 panic = "abort"
 


### PR DESCRIPTION
This is `build` but it also ~a~effects `ci`. This has benefits:
- faster release builds by default (good for testing `cfg`s)
- `release` includes debug-info and panic-unwinding

It has the drawback that CI needs adjustment to allow users to get the `opt` version without building themselves