### PR TITLE
build(cargo): don't use `mold`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,2 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
-
-[target.x86_64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ win32console = "^0.1.5"
 
 [profile.release]
 lto = "thin"
+opt-level = 2
 codegen-units = 4
 
 [profile.opt]


### PR DESCRIPTION
- this uses whatever linker is installed on the system, until rust-lang/rust#140525 is merged
- additionally config something I missed in #1008

The reasoning for this is that `mold` should only be used for incremental builds. It's not appropriate if the user/dev wants more stability and less bugs.

If any `mold` contributor reads this, we appreciate the work being done on `mold` to improve this situation! It's just that we want to isolate sources of issues, as we already have enough problems with `wgpu`.

An alternative patch would be to edit CI to generate release-artifacts without `mold`, while keeping `mold` enabled in `.cargo/config.toml`