### PR TITLE
 feat(ui): add copy button to copy error messages

### DIFF
--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -91,6 +91,7 @@ pub enum Message {
     ExportSelection,
     SelectionExported(Result<bool, String>),
     DescriptionEdit(text_editor::Action),
+    CopyError(String),
 }
 
 pub struct SummaryEntry {
@@ -368,6 +369,7 @@ impl List {
                 }
                 Command::none()
             }
+            Message::CopyError(err) => iced::clipboard::write::<Message>(err),
         }
     }
 
@@ -925,6 +927,13 @@ fn error_view<'a>(
     .center_x();
 
     let modal_btn_row = row![
+        button(
+            text("Copy error")
+                .width(Length::Fill)
+                .horizontal_alignment(alignment::Horizontal::Center),
+        )
+        .width(Length::Fill)
+        .on_press(Message::CopyError(error.to_string())),
         button(
             text("Close")
                 .width(Length::Fill)

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -375,7 +375,9 @@ impl List {
                 self.copy_confirmation = true;
                 Command::batch(vec![
                     iced::clipboard::write::<Message>(err),
-                    Command::perform(Self::delay_hide_copy_confirmation(), |_| Message::HideCopyConfirmation)
+                    Command::perform(Self::delay_hide_copy_confirmation(), |_| {
+                        Message::HideCopyConfirmation
+                    }),
                 ])
             }
             Message::HideCopyConfirmation => {
@@ -945,13 +947,25 @@ fn error_view<'a>(
 
     let modal_btn_row = row![
         button(
-            text(if copy_confirmation { "Copied!" } else { "Copy error" })
-                .width(Length::Fill)
-                .horizontal_alignment(alignment::Horizontal::Center),
+            text(if copy_confirmation {
+                "Copied!"
+            } else {
+                "Copy error"
+            })
+            .width(Length::Fill)
+            .horizontal_alignment(alignment::Horizontal::Center),
         )
         .width(Length::Fill)
-        .on_press_maybe(if copy_confirmation { None } else { Some(Message::CopyError(error.to_string())) })
-        .style(if copy_confirmation { style::Button::Primary } else { style::Button::default() }),
+        .on_press_maybe(if copy_confirmation {
+            None
+        } else {
+            Some(Message::CopyError(error.to_string()))
+        })
+        .style(if copy_confirmation {
+            style::Button::Primary
+        } else {
+            style::Button::default()
+        }),
         button(
             text("Close")
                 .width(Length::Fill)


### PR DESCRIPTION
**Pull Request Description:** This PR introduces a `Copy error` button to the ADB error modal. When an ADB operation fails, users can now easily copy the error message to their clipboard for troubleshooting or sharing. After clicking the button, the label changes to `Copied!` to provide immediate feedback. This enhancement improves user experience by making error reporting and support requests more convenient.

**_A demonstration of the new feature is attached below:_**

![uad-ng_JxwY5uamZ1](https://github.com/user-attachments/assets/35031ea0-7bd5-4d08-9711-3d6ef2b5d6e6)
