### PR TITLE
fix(list-description-crash): add null action on scroll

### DIFF
--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -364,6 +364,7 @@ impl List {
                     text_editor::Action::Edit(_) => {
                         // Do nothing - ignore all editing operations
                     }
+                    text_editor::Action::Scroll { lines } => { }
                     // Allow all other actions (movement, selection, clicking, scrolling, etc.)
                     _ => {
                         self.description_content.perform(action);

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -364,7 +364,7 @@ impl List {
                     text_editor::Action::Edit(_) => {
                         // Do nothing - ignore all editing operations
                     }
-                    text_editor::Action::Scroll { lines } => { }
+                    text_editor::Action::Scroll { lines } => {}
                     // Allow all other actions (movement, selection, clicking, scrolling, etc.)
                     _ => {
                         self.description_content.perform(action);


### PR DESCRIPTION
I experienced a crash when accidentally scrolling with the mouse on the text edit containing the add description. This hack fixed it for me, but it might cause issues in cases there's an actual need to scroll. Any ideas?