### PR TITLE
build(script): use `embed_resource` appropriately

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,9 @@ const META: &str = "resources/assets/manifest.rc";
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo::rerun-if-changed={META}");
     if std::env::var("CARGO_CFG_TARGET_FAMILY")? == "windows" {
-        embed_resource::compile(META, embed_resource::NONE);
+        embed_resource::compile(META, embed_resource::NONE)
+            .manifest_optional()
+            .unwrap();
     }
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,9 @@
-use std::{env, error::Error};
+const META: &str = "resources/assets/manifest.rc";
 
-fn main() -> Result<(), Box<dyn Error>> {
-    if env::var("CARGO_CFG_TARGET_FAMILY")? == "windows" {
-        embed_resource::compile("resources/assets/manifest.rc", embed_resource::NONE);
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo::rerun-if-changed={META}");
+    if std::env::var("CARGO_CFG_TARGET_FAMILY")? == "windows" {
+        embed_resource::compile(META, embed_resource::NONE);
     }
-
     Ok(())
 }


### PR DESCRIPTION
- slightly improves build speed
- uses `embed_resource` according to the example-usage in its `README`
- fixes a compiler warn (`unused_must_use`)