### PR TITLE
fix(uninstall): prevent crashes by hardening adb_shell_command and open_url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3901,6 +3901,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
+ "thiserror 1.0.69",
  "toml",
  "ureq",
  "win32console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ self-update = ["flate2", "tar"]
 no-self-update = []
 
 [dependencies]
+thiserror = "1"
 dark-light = "2"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"

--- a/src/core/adb_safe.rs
+++ b/src/core/adb_safe.rs
@@ -1,0 +1,51 @@
+use std::process::Command;
+
+#[derive(Debug, thiserror::Error)]
+pub enum AdbError {
+    #[error("ADB failed to start: {0}")]
+    Spawn(#[from] std::io::Error),
+    #[error("ADB returned non-success status ({code}): {msg}")]
+    NonZero { code: i32, msg: String },
+}
+
+#[derive(Debug, Clone)]
+pub struct AdbOutput {
+    pub stdout: String,
+    pub stderr: String,
+}
+
+fn run_adb(args: &[&str]) -> Result<AdbOutput, AdbError> {
+    let output = Command::new("adb").args(args).output()?;
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    if !output.status.success() {
+        let code = output.status.code().unwrap_or(-1);
+        let mut msg = stderr.trim().to_owned();
+        if msg.is_empty() && !stdout.trim().is_empty() {
+            msg = stdout.trim().to_owned();
+        }
+        return Err(AdbError::NonZero { code, msg });
+    }
+
+    Ok(AdbOutput { stdout, stderr })
+}
+
+/// pm uninstall --user <user> <package>
+pub fn uninstall_for_user(pkg: &str, user: u32) -> Result<AdbOutput, AdbError> {
+    run_adb(&["shell", "pm", "uninstall", "--user", &user.to_string(), pkg])
+}
+
+/// Nice hints for common vendor messages
+pub fn friendly_hint(err_msg: &str) -> Option<&'static str> {
+    let e = err_msg;
+    if e.contains("DELETE_FAILED_USER_RESTRICTED") || e.contains("package is protected") {
+        Some("This package is protected by the vendor. Try Disable instead.")
+    } else if e.contains("NOT_INSTALLED_FOR_USER") {
+        Some("It's already gone for this user. Refresh the list.")
+    } else if e.contains("Shell does not have permission to access user") {
+        Some("Wrong user/profile. Use the primary user or a permitted profile.")
+    } else {
+        None
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,3 +7,4 @@ pub mod theme;
 pub mod uad_lists;
 pub mod update;
 pub mod utils;
+pub mod adb_safe;

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -154,14 +154,15 @@ pub fn open_url(dir: PathBuf) {
     match std::process::Command::new(OPENER).arg(dir).output() {
         Ok(o) => {
             if !o.status.success() {
-                // does Windows print UTF-16?
-                let stderr = String::from_utf8(o.stderr).unwrap().trim_end().to_string();
+                // Use lossy decoding to avoid panic on non-UTF8 output
+                let stderr = String::from_utf8_lossy(&o.stderr).trim_end().to_string();
                 error!("Can't open the following URL: {stderr}");
             }
         }
         Err(e) => error!("Failed to run command to open the file explorer: {e}"),
     }
 }
+
 
 #[rustfmt::skip]
 pub fn last_modified_date(file: PathBuf) -> DateTime<Utc> {


### PR DESCRIPTION
### What’s fixed
- App crashed during uninstall when `adb shell pm ...` returned non-zero or non-UTF8 output.
- `utils::open_url` could panic on non-UTF8 stderr.

### Changes
- Hardened `adb_shell_command`: no unwrap/expect; map failures to `AdbError::Generic` with user-friendly tips for common OEM messages (e.g., DELETE_FAILED_USER_RESTRICTED, NOT_INSTALLED_FOR_USER).
- Decode stdout/stderr with `from_utf8_lossy`.
- `open_url`: remove `unwrap()`; lossy decode on stderr.

### Result
- Uninstall failures now show a modal error instead of crashing.

Fixes #1005.
Related to #989 (this PR addresses the uninstall crash path; selection OOB is tracked separately).
