### PR TITLE
move com.amazon.venezia to advanced

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -12790,11 +12790,11 @@
   },
   "com.amazon.venezia": {
     "list": "Misc",
-    "description": "Amazon AppStore\n",
+    "description": "Amazon AppStore\n Removal will result in breakage of app drawer on Amazon Fire TV devices.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   "com.amazon.aa": {
     "list": "Misc",


### PR DESCRIPTION
Due to it breaking the app drawer on Fire TV, I'd put it as advanced, as it renders the device a lot harder to use unless an alternative launcher is installed.