### PR TITLE
pkg(yandex, vk): add Russian packages

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -14676,6 +14676,14 @@
     "labels": [],
     "removal": "Recommended"
   },
+  "com.yandex.searchapp": {
+    "list": "Oem",
+    "description": "Yandex' Search App\nRussian search app, similar to the Google search bar that appears on the phone's home screen.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
   "ru.yandex.disk": {
     "list": "Oem",
     "description": "Yandex' file cloud storage\nMay be installed with Samsung firmware update to comply with http://publication.pravo.gov.ru/Document/View/0001202011230051 if you're Russian. Can be installed manually from Google Play.",
@@ -14695,6 +14703,46 @@
   "ru.yandex.yandexmaps": {
     "list": "Oem",
     "description": "Yandex' Maps\nMay be installed with Samsung firmware update to comply with http://publication.pravo.gov.ru/Document/View/0001202011230051 if you're Russian. Can be installed manually from Google Play.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "ru.vk.store": {
+    "list": "Oem",
+    "description": "Rustore, russian app market, preinstalled by russian law from 2019",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "ru.ivi.client": {
+    "list": "Oem",
+    "description": "Ivi, russian video service, preinstalled by russian law from 2019",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "ru.litres.android": {
+    "list": "Oem",
+    "description": "Litres, russian bookstore service, preinstalled by russian law from 2019",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "ru.ozon.app.android": {
+    "list": "Oem",
+    "description": "Ozon, russian marketplace, preinstalled by russian law from 2019",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "ru.dublgis.dgismobile": {
+    "list": "Oem",
+    "description": "2GIS, russian mapping service, preinstalled by rus law from 2019",
     "dependencies": [],
     "neededBy": [],
     "labels": [],


### PR DESCRIPTION
duplicate: com.yandex.browser -> Old description is better
added: com.yandex.searchapp -> I think this package is this app https://4phone.app/yandex-search/com.yandex.searchapp
duplicate: ru.yandex.yandexmaps -> Old description is better 
added: ru.vk.store -> nothing to add
added: ru.ivi.client -> Searching for the package this is the first result, its probably this app https://play.google.com/store/apps/details?id=ru.ivi.client
added: ru.litres.android -> Nothing to Add, https://www.litres.ru/app/ this is probably what the package is 
added: ru.ozon.app.android -> Probably this app https://play.google.com/store/apps/details?id=ru.ozon.app.android
added: ru.dublgis.dgismobile -> This app https://2gis.ru

None of them should break functionalities thats why I only set to Recommended

Most of them should not configure as Oem, but Im following what mtxadmin said about these apps being preinstalled, we could change to misc! 

