### PR TITLE
Fix some text doesn't render in some devices.

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -8,10 +8,9 @@ use crate::core::theme::{OS_COLOR_SCHEME, Theme};
 use crate::core::uad_lists::UadListState;
 use crate::core::update::{Release, SelfUpdateState, SelfUpdateStatus, get_latest_release};
 use crate::core::utils::{NAME, string_to_theme};
-
+use iced::Font;
 use iced::advanced::graphics::image::image_rs::ImageFormat;
 use iced::font;
-use iced::Font;
 use iced::window::icon;
 use views::about::{About as AboutView, Message as AboutMessage};
 use views::list::{List as AppsView, LoadingState as ListLoadingState, Message as AppsMessage};


### PR DESCRIPTION
Its weird that the default font doesn't render in some system, So change it to Monospace,
Reference:
https://github.com/iced-rs/iced/issues/2563


Fixes #1135. and its closed siblings 