### PR TITLE
pkg(com.dot.app.sancharsaathi): Add Sanchar Saathi App

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -40550,5 +40550,14 @@
     "neededBy": [],
     "labels": [],
     "removal": "Recommended"
+  },
+ "com.dot.app.sancharsaathi": {
+    "list": "Carrier",
+    "description": "Spyware billed as citizen-centric safety tool that is required by Goverment of India be pre-installed.\nhttps://www.reuters.com/sustainability/boards-policy-regulation/what-is-indias-politically-contentious-sanchar-saathi-cyber-safety-app-2025-12-02",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
   }
+
 }


### PR DESCRIPTION
Sanchar Saathi is a spyware that will be soon be forcefully installed in all Android, and probably Apple too, devices in India. More info in this [Reuters article](https://www.reuters.com/sustainability/boards-policy-regulation/what-is-indias-politically-contentious-sanchar-saathi-cyber-safety-app-2025-12-02)

I am submitting this patch in advance, so users can remove it when it is pushed, and to implement any feedback.