### PR TITLE
pkg(com.huawei.imedia.sws): update description

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -3311,7 +3311,7 @@
   },
   "com.huawei.imedia.sws": {
     "list": "Oem",
-    "description": "Huawei Histen\nAudio 3D effects found in the settings. Safe to remove if you don't use these settings.",
+    "description": "Huawei Histen\nAudio 3D effects found in the settings. Safe to remove if you don't use these settings.\nCauses an audio glitch after the first reboot following the uninstallation or disabling of this package.\nWhen you start or resume playing any audio content in any media application, the sound volume initially sets to maximum for half a second, then normalizes.\nAffects only external audio devices with any connection type.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],


### PR DESCRIPTION
Update description due to a found glitch.
EMUI 12.0.0
Android 10

`com.huawei.imedia.sws`:
Causes an audio glitch after the first reboot following the uninstallation or disabling of this package.
When you start or resume playing any audio content in any media application, the sound volume initially sets to maximum for half a second, then normalizes. 
Affects only external audio devices with any connection type.