### PR TITLE
fix: shell issues for packages that can't be enabled

### DIFF
--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -1188,7 +1188,7 @@ impl List {
                                     .find(|(_, p)| p.name == pkg_name_str);
 
                                 if let Some((index, _)) = found_pkg {
-                                    let user = user_ref.clone();
+                                    let user = *user_ref;
                                     let device = selected_device.clone();
                                     let pkg_name = pkg_name_str.to_string();
 
@@ -1205,7 +1205,7 @@ impl List {
                                                 crate::core::sync::apply_pkg_state_commands(
                                                     &temp_pkg,
                                                     PackageState::Uninstalled,
-                                                    user.clone(),
+                                                    user,
                                                     &device,
                                                 );
 
@@ -1230,7 +1230,7 @@ impl List {
                                                 crate::core::sync::apply_pkg_state_commands(
                                                     &temp_pkg_uninstalled,
                                                     PackageState::Enabled,
-                                                    user.clone(),
+                                                    user,
                                                     &device,
                                                 );
 
@@ -1258,8 +1258,7 @@ impl List {
                                                 index,
                                                 new_state: actual_state,
                                                 notification: Some(format!(
-                                                    "Attempted recovery for {}",
-                                                    pkg_name
+                                                    "Attempted recovery for {pkg_name}"
                                                 )),
                                                 error_modal: None,
                                             }


### PR DESCRIPTION
closes #514 

### what has been implemented

- this should handle the specific bug that is found in issue 514, basically it checks for the specific error pattern in the log and fixes it accordingly. However, this is limited by the following issues found.

### issues

- the handling of issues, the _on_verify_and_fallback_ function specifically, has many issues that have been explained in the comments. which TL;DR it deals very poorly with hard issues(adb command errors)
-massive code block
-generic error handling

The result is a very non-scalable error handling function.

### Help needed

while reviewing this code make sure to get the PR onto your computer and test it out on a VM using android studio, try to replicate the exact issue and contact me directly on discord with the logs and the exact setup. so that I may follow up on the fixup. I was not able to replicate the issue with this fix so it should... in theory be fixed.

