### PR TITLE
chore(git): add `.mailmap`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,11 @@
+Rudxain <rudxain@localhost.localdomain>
+Rudxain <76864299+Rudxain@users.noreply.github.com> Ricardo Fernández Serrata <76864299+Rudxain@users.noreply.github.com>
+Anonymoussaurus <50231698+AnonymousWP@users.noreply.github.com> AnonymousWP <50231698+AnonymousWP@users.noreply.github.com>
+Anonymoussaurus <anonymouswp@oxygenupdater.com>
+# w1nst0n
+# 0x192
+# “Frigyes06”
+# Frigyes
+# Frigyes06
+# Frigyes Erdosi-Szucs
+# Frigyes Erdosi Szucs


### PR DESCRIPTION
Quoting [myself](https://discord.com/channels/1168607797081022514/1171387180409692160/1427546899627380746) (team channel):
> I'm writing a `.mailmap` file for the repo because I was annoyed at the duplicate contributors listed by Git. It seems Frigyes has [70 alt accounts](https://youtu.be/4sDuNccDw80) 🥲

[Adhiraj](https://github.com/adhirajsinghchauhan) said:
> I don't see any dupes in https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/graphs/contributors

Which is 99.9% true, but the problem is more noticeable when using `git` (CLI) locally (such as `git shortlog -sn`)

[`man`-page](https://git-scm.com/docs/gitmailmap)