### PR TITLE
pkg(IMEs): dedupe info; `Recommended`->`Advanced`

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -38006,11 +38006,11 @@
   },
   "com.iflytek.inputmethod.miui": {
     "list": "Oem",
-    "description": "Chinese Keyboard to Miui China, replace Keyboard before remove.",
+    "description": "Chinese Keyboard to Miui China",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   "com.xiaomi.ugd": {
     "list": "Oem",
@@ -39568,11 +39568,11 @@
   },
   "com.onyx.latinime": {
     "list": "Oem",
-    "description": "The Onyx Keyboard. Removing it will leave withe google STT keyboard.",
+    "description": "The Onyx Keyboard. The Google STT keyboard might be available to replace it.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   "com.onyx.mail": {
     "list": "Oem",
@@ -39600,7 +39600,7 @@
   },
   "com.preff.kb.xm": {
     "list": "Oem",
-    "description": "'Emoji & Font Keyboard' on Xiaomi.\nXiaomi won't let me uninstall it. If it's same for you, consider disabling it instead.\nMake sure to install an alternate keyboard app before doing so.",
+    "description": "'Emoji & Font Keyboard' on Xiaomi",
     "dependencies": [],
     "neededBy": [],
     "labels": [],


### PR DESCRIPTION
This removes info that's "redundant" within the list, or because the wiki already has the info. It also moves some [IMEs](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/wiki/Glossary#IME) to `Advanced`.

The diff was going to be bigger, because I wanted to dedupe more info, but I gave up