### PR TITLE
docs(readme): add privacy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This can also improve security by reducing the [attack surface](https://en.wikip
 ## Documentation
 
 Everything about UAD-ng (and related stuff) can be found on [the Wiki](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/wiki), such as:
+
 - Features of this app
 - [Usage guide](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/wiki/Usage)
 - Suggested Android app replacements


### PR DESCRIPTION
Added a new section detailing that UAD-ng does not collect or transmit user data, and specifying the only external connections made are to GitHub for package lists and updates.