### PR TITLE
ci(releases): add note about package list updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,6 @@ jobs:
         with:
           files: uad-ng-*/*
           generate_release_notes: true
+          body: |
+            > [!NOTE]
+            > 📦 **Package list updates don't require a new app version**—UAD-ng automatically fetches the latest package definitions on launch (requires internet connection).


### PR DESCRIPTION
Added a note to the release workflow clarifying that package list updates do not require a new app version, as UAD-ng fetches the latest package definitions on launch if connected to the internet.