### PR TITLE
docs(readme): remove line numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Everything about UAD-ng (and related stuff) can be found on [the Wiki](https://g
 
 ## Privacy
 
-UAD-ng does not collect or transmit any user data. The only external connections are `GET` requests to GitHub for fetching the [package list](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/blob/main/resources/assets/uad_lists.json) ([src/core/uad_lists.rs#L210](src/core/uad_lists.rs#L210)) and checking for updates ([src/core/update.rs#L178](src/core/update.rs#L178)).
+UAD-ng does not collect or transmit any user data. The only external connections are `GET` requests to GitHub for fetching the [package list](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/blob/main/resources/assets/uad_lists.json) ([src/core/uad_lists.rs](src/core/uad_lists.rs)) and checking for updates ([src/core/update.rs](src/core/update.rs)).
 
 ## Contact
 


### PR DESCRIPTION
Because line numbers can change, it's hard to reference, see https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/1231#discussion_r2672430419.