### PR TITLE
fix(window): incorrect title of UAD-ng

### DIFF
--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -17,6 +17,8 @@ use std::{
 
 /// Canonical shortened name of the application
 pub const NAME: &str = "UAD-ng";
+/// Full name of the application
+pub const FULL_NAME: &str = "Universal Android Debloater Next Generation";
 pub const EXPORT_FILE_NAME: &str = "selection_export.txt";
 
 /// Returns `true` if `c` matches the regex `\w`

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -7,7 +7,7 @@ use crate::core::sync::{Phone, get_devices_list, initial_load};
 use crate::core::theme::{OS_COLOR_SCHEME, Theme};
 use crate::core::uad_lists::UadListState;
 use crate::core::update::{Release, SelfUpdateState, SelfUpdateStatus, get_latest_release};
-use crate::core::utils::{NAME, string_to_theme};
+use crate::core::utils::{FULL_NAME, NAME, string_to_theme};
 
 use iced::font;
 use iced::window::icon;
@@ -75,6 +75,10 @@ pub enum Message {
 }
 
 impl UadGui {
+    fn title(&self) -> String {
+        FULL_NAME.to_string()
+    }
+
     fn new() -> (Self, Task<Message>) {
         (
             Self::default(),
@@ -383,6 +387,7 @@ impl UadGui {
         };
 
         iced::application(UadGui::new, UadGui::update, UadGui::view)
+            .title(UadGui::title)
             .theme(UadGui::theme)
             .settings(Settings {
                 id: Some(String::from(NAME)),

--- a/src/gui/views/about.rs
+++ b/src/gui/views/about.rs
@@ -3,7 +3,7 @@ use crate::core::adb;
 use crate::core::helpers::button_primary;
 use crate::core::theme::Theme;
 use crate::core::uad_lists::LIST_FNAME;
-use crate::core::utils::{NAME, last_modified_date, open_url};
+use crate::core::utils::{FULL_NAME, NAME, last_modified_date, open_url};
 use crate::gui::{UpdateState, style, widgets::text};
 use iced::widget::{Space, column, container, row};
 use iced::{Alignment, Element, Length, Renderer};
@@ -39,7 +39,7 @@ impl About {
     )]
     pub fn view(&self, update_state: &UpdateState) -> Element<'_, Message, Theme, Renderer> {
         let about_text = text(format!(
-            "Universal Android Debloater Next Generation ({NAME}) is a free and open-source community project \naiming at simplifying the removal of pre-installed apps on any Android device."
+            "{FULL_NAME} ({NAME}) is a free and open-source community project \naiming at simplifying the removal of pre-installed apps on any Android device."
         ));
 
         let descr_container = container(about_text)


### PR DESCRIPTION
Cause: iced update to 0.14.

Fix: https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/actions/runs/20849662020.

Seems to work fine now: 
<img width="324" height="40" alt="image" src="https://github.com/user-attachments/assets/176672bf-5ce9-4a97-963c-ba53f1c18b7e" />
