### PR TITLE
ci(release): move packages to bottom of release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,11 +9,6 @@ changelog:
     - title: Refactors
       labels:
         - refactor
-    - title: Packages/apps
-      labels:
-        - package::documentation
-        - package::addition
-        - package::breakage
     - title: Development
       labels:
         - ci
@@ -21,3 +16,8 @@ changelog:
     - title: Documentation
       labels:
         - documentation
+    - title: Packages/apps
+      labels:
+        - package::documentation
+        - package::addition
+        - package::breakage


### PR DESCRIPTION
This pull request makes a minor adjustment to the `.github/release.yml` configuration, specifically reordering the `Packages/apps` section to appear after `Documentation` in the changelog header. No functional changes were made; this is purely organisational.