### PR TITLE
chore(cargo-clippy): rm no-op lint line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ format_push_string = "warn"
 large_include_file = "warn"
 shadow_unrelated = "warn"
 struct_field_names = "allow" # annoying
-module_name_repetitions = "allow" # annoying
 
 disallowed_types = "deny"
 disallowed_methods = "deny"


### PR DESCRIPTION
One of Clippy's releases has moved `module_name_repetitions` from `pedantic` to `restriction` (rust-lang/rust-clippy#13541), so it's already `allow` by default.

If there are any other lint-levels that are redundant (such as an explicit `warn` that's already `warn` by default), please let me know so that it can be fixed in this same PR