### PR TITLE
pkg(docomo, samsung, felica): add docomo pkg, update FeliCa pkg

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -33588,7 +33588,7 @@
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Advanced"
+    "removal": "Recommended"
   },
   "com.nttdocomo.android.mascot": {
     "list": "Carrier",


### PR DESCRIPTION
- add lots of docomo package (only confirmed on SC-53E, more can be found on older devices)
- some fixes to FeliCa pkg

I think this is time to add docomo in [Cellular carriers](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/wiki/Debloat-Lists#cellular-carriers), how about this?