### PR TITLE
chore(issue-templates): add checkbox for reading about removals

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-add-new-packages.yml
+++ b/.github/ISSUE_TEMPLATE/3-add-new-packages.yml
@@ -16,7 +16,7 @@ body:
 
       **List**: `Google`|`Misc`|`OEM` (manufacturer) |`AOSP`|`Pending`|`Carrier` (ISP).
 
-      **Removal**: See the [Removal Definitions](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/wiki/Debloat-Lists#removal-definitions) on the wiki for details. **Please ensure you follow these definitions when proposing changes.**
+      **Removal**: `Recommended`|`Advanced`|`Expert`|`Unsafe`. See the [Removal Definitions](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/wiki/Debloat-Lists#removal-definitions) on the wiki for details. **Please ensure you follow these definitions when proposing changes.**
 
 - type: textarea
   id: package-listing

--- a/.github/ISSUE_TEMPLATE/5-update-apps-description-or-recommendation.yml
+++ b/.github/ISSUE_TEMPLATE/5-update-apps-description-or-recommendation.yml
@@ -16,7 +16,7 @@ body:
 
       **List**: `Google`|`Misc`|`OEM` (manufacturer) |`AOSP`|`Pending`|`Carrier` (ISP).
 
-      **Removal**: See the [Removal Definitions](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/wiki/Debloat-Lists#removal-definitions) on the wiki for details. **Please ensure you follow these definitions when proposing changes.**
+      **Removal**: `Recommended`|`Advanced`|`Expert`|`Unsafe`. See the [Removal Definitions](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/wiki/Debloat-Lists#removal-definitions) on the wiki for details. **Please ensure you follow these definitions when proposing changes.**
 
 - type: textarea
   id: package-listing


### PR DESCRIPTION
This pull request adds a new required checkbox to two issue templates to ensure contributors confirm they have read the project's "Removal Definitions" guidelines before submitting changes. This helps maintain consistency and adherence to project standards when proposing package additions or app description/recommendation updates. Reason why this was done is because it's important to read the wiki, to prevent users from submitting packages with a wrong removal.