### PR TITLE
pkg(com.apple.atve.androidtv.appletv): add package

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -42055,5 +42055,13 @@
     "neededBy": [],
     "labels": [],
     "removal": "Recommended"
+  },
+  "com.apple.atve.androidtv.appletv": {
+    "list": "Oem",
+    "description": "Apple TV\nFactory-installed Apple TV app. Reverts to factory-version when uninstalled by normal means.\n(Shipped with Philips Android TVs, but may be present on other devices as well.)\nhttps://play.google.com/store/apps/details?id=com.apple.atve.androidtv.appletv",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
   }
 }


### PR DESCRIPTION
- https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/issues/1291
  
  > \- Package name: com.apple.atve.androidtv.appletv
  > \- List: OEM
  > \- Removal: Recommended
  > \- Description: Apple TV
  >     Factory-installed Apple TV app. Reverts to factory-version when uninstalled by normal means.
  >     (Shipped with Philips Android TVs, but may be present on other devices as well.)
  >     https://play.google.com/store/apps/details?id=com.apple.atve.androidtv.appletv