### PR TITLE
pkg: change descriptions for soundalive & scpm

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -5643,11 +5643,11 @@
   },
   "com.samsung.android.scpm": {
     "list": "Oem",
-    "description": "Samsung Cloud Platform Manager\nRelated to Samsung Cloud.\nNOTE: Uninstalling it causes the \"Sound Quality and Effects\" app (com.sec.android.app.soundalive) to crash regularly, resulting in a crash dialog that might become annoying. (However, the sound seems to work fine. Disabling scpm does not seem to cause errors.)",
+    "description": "Samsung Cloud Platform Manager\nRelated to Samsung Cloud.\nNOTE: Uninstalling or disabling this app causes the \"Sound Quality and Effects\" app (com.sec.android.app.soundalive) to crash regularly, resulting in a crash dialog that might become annoying. (However, the sound seems to work fine)",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   "com.samsung.android.sconnect": {
     "list": "Oem",
@@ -7248,7 +7248,7 @@
   },
   "com.sec.android.app.soundalive": {
     "list": "Oem",
-    "description": "Responsible for Dolby Atmos and other equalizer stuff (accessible from the Settings app).\nNeeded by Adapt Sound (com.sec.hearingadjust) which is a pretty useful feature.\nNOTE: If the app crashes regularly, even when you don't use Dolby or other features, check to see if you have \"com.samsung.android.scpm\" installed. If not, try installing it. (Disabling scpm seems to be okay)",
+    "description": "Responsible for Dolby Atmos and other equalizer stuff (accessible from the Settings app).\nNeeded by Adapt Sound (com.sec.hearingadjust) which is a pretty useful feature.\nNOTE: If the app crashes regularly, even when you don't use Dolby or other features, check to see if you have \"com.samsung.android.scpm\" installed & enabled. If not, try installing/enabling it.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],


### PR DESCRIPTION
Updated descriptions for Samsung Cloud Platform Manager and SoundAlive apps to include additional notes on uninstallation and potential issues.

## Description

After debloating my Samsung Galaxy S26 Ultra, I encountered an issue where the "Sound Quality and Effects" app kept crashing and displaying a crash dialog. (Even though the sounds seemed to work fine.)
After running logcat, I found the issue:

```
AndroidRuntime: FATAL EXCEPTION: binder:17789_8
AndroidRuntime: Process: com.sec.android.app.soundalive, PID: 17789
...
Caused by: java.lang.IllegalArgumentException: Unknown authority com.samsung.android.scpm.policy
...
```

Even after disabling Dolby and all the other features, the app would periodically crash and display the crash dialog, which was annoying. After reinstalling `com.samsung.android.scpm`, it worked fine. I then disabled `scpm`, and I haven't had any issues since.
Note: I only tested this with YouTube.

## Documentation Changes

I have adjusted the descriptions of `com.samsung.android.scpm` and `com.sec.android.app.soundalive` to highlight the error mentioned above.

## Checklist

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/blob/main/CONTRIBUTING.md)
- [x] My changes are clear and easy to understand
- [x] I have checked for grammar and spelling errors
- [x] I have verified all links are correct
- [x] I have tested any code examples provided
- [x] The documentation is properly formatted with markdown