### PR TITLE
fix(gui): explicitly request Adwaita Sans font on Linux to prevent Bounding Box clipping from monospace fallback

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -416,6 +416,8 @@ impl UadGui {
             .settings(Settings {
                 id: Some(String::from(NAME)),
                 default_text_size: iced::Pixels(16.0),
+                #[cfg(target_os = "linux")]
+                default_font: iced::Font { family: iced::font::Family::Name("Adwaita Sans"), ..Default::default() },
                 ..Settings::default()
             })
             .window(Window {


### PR DESCRIPTION
# UAD-ng Linux UI Rendering Bug: Font Metrics & Clipping

## The Issue
On Linux systems (specifically tested on Arch Linux via Wayland and X11), users may experience a severe UI rendering bug where:
1.  **Text is aggressively clipped/invisible**: Dropdown menus (PickLists), checkboxes, and radio buttons appear completely empty.
2.  **Extreme kerning/spacing**: Text that does render (like the version number "v 1 . 2 . 0") has massive gaps between characters.

This is **not** a GPU, `wgpu`, or Wayland driver bug.

## Root Cause
The root cause lies in how Iced's `cosmic-text` engine interacts with `fontconfig` defaults on Linux.

By default, Iced requests the generic `sans-serif` font family. If a user's `fontconfig` maps `sans-serif` to a heavily stylized, monospace, or non-standard metric font (for example, `Monaspace Neon WideBold` or certain CJK fonts with aggressive English glyph replacements), the font metrics engine calculates an enormous width for each character.

Because UI components like `PickList` and `Checkbox` have strict bounding boxes, the engine attempts to draw the overly-wide text and immediately clips it 100%, resulting in empty UI elements.

## The Fix
Instead of relying solely on the highly unpredictable `sans-serif` default alias from the user's OS, we can provide a safer font fallback chain in `Settings::default()`. By explicitly requesting a standard, UI-safe font like `Adwaita Sans` (which is virtually guaranteed to exist on any Linux system with GTK installed) before falling back, we bypass the polluted `sans-serif` alias and restore correct UI rendering.

### Suggested PR Implementation

```rust
// In src/gui/mod.rs -> UadGui::start()
.settings(Settings {
    id: Some(String::from(NAME)),
    default_text_size: iced::Pixels(16.0),
    #[cfg(target_os = "linux")]
    default_font: iced::Font {
        // Workaround for broken `sans-serif` default metric fallbacks
        // We try to request a standard Linux GUI font by name.
        // Note: `iced`'s fontdb will still fall back to `sans-serif` if this is not found.
        family: iced::font::Family::Name("Adwaita Sans"),
        ..Default::default()
    },
    ..Settings::default()
})
```

### Preview

before:
<img width="958" height="733" alt="uad1" src="https://github.com/user-attachments/assets/b3382d5b-a519-4fa8-bd47-bd4306f7c27a" />


after:
<img width="957" height="734" alt="uad2" src="https://github.com/user-attachments/assets/b58d2cd4-d201-4e05-be01-450b9a748ff3" />


By requesting `Adwaita Sans` first, `fontdb` will use it to calculate accurate font metrics, ensuring proper layout and preventing UI clipping, without requiring us to bloat the repository with bundled `.ttf` files.

## Checklist

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] The CI/CD pipeline passes (or is expected to pass)
