### PR TITLE
pkg(aosp): change removals and descriptions

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -8097,8 +8097,8 @@
     "removal": "Recommended"
   },
   "com.android.runintest.ddrtest": {
-    "list": "Aosp",
-    "description": "DDR Test\nRAM Stress tester\nCan be run from the bootloader\nNOTE: I'm not sure it's really from AOSP (seen in TCL Plex phone)\n",
+    "list": "Oem",
+    "description": "DDR Test\nRAM Stress tester\nCan be run from the bootloader\n(seen in TCL Plex phone)\n",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
@@ -8106,11 +8106,11 @@
   },
   "com.android.safetycenter.resources": {
     "list": "Aosp",
-    "description": "Google Safety Center.\nProbably affects malware detection in new app installs, Gmail, and Chrome. This will also revert back the\"Security & privacy\" look to the old style.\nYou can use a libre spam-blocking and DNS-blocking solution instead of this.\nhttps://safety.google",
+    "description": "Google/AOSP Safety Center resources.\n. Uninstalling this will change the configuration to revert back the\"Security & privacy\" look to the old style.\nDoes not contain code, just the configuration for code that lives in another package.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   "com.android.sdksandbox": {
     "list": "Aosp",
@@ -8282,7 +8282,7 @@
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   "com.android.captiveportallogin": {
     "list": "Aosp",
@@ -8748,7 +8748,7 @@
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   "com.google.android.contactkeys": {
     "list": "Google",
@@ -23426,8 +23426,8 @@
     "labels": []
   },
   "com.svox.pico": {
-    "description": "Pico TTS\nHidden sample voice data. Useless.",
-    "removal": "Recommended",
+    "description": "Pico TTS\nOpen source TTS engine shipped on old Android devices and some custom ROMs\nUninstalling this without installing a TTS engine will break TTS, it also doesn't access the internet so there's not much to gain",
+    "removal": "Advanced",
     "list": "Oem",
     "dependencies": [],
     "neededBy": [],
@@ -32255,11 +32255,11 @@
   },
   "com.android.fmradio": {
     "list": "Aosp",
-    "description": "FM Radio\n Plug in Head phones & listen to the Radio!\n",
+    "description": "FM Radio\n Plug in Head phones & listen to the Radio!\nUninstalling will break FM Radio until reinstalled, and no other FM apps can be downloaded from app stores",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   "com.haoba.btsmart": {
     "list": "Misc",
@@ -34980,7 +34980,7 @@
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   "com.android.healthconnect.controller": {
     "list": "Aosp",
@@ -34988,15 +34988,15 @@
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   "com.android.virtualmachine.res": {
     "list": "Aosp",
-    "description": "unknown app with no code that only has permissions to Use, Manage, Debug: Virtual Machine.\nIntroduced in Android 14.",
+    "description": "Empty app with no code that declares permissions to Use, Manage, Debug: Virtual Machine for use by other apps. Deleting this app may cause potential security issues because another app could redefine the permissions with lower restriction level. Nothing to gain by removing.\nIntroduced in Android 14.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Expert"
   },
   "com.android.rkpdapp": {
     "list": "Aosp",
@@ -35012,7 +35012,7 @@
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   "com.android.systemui.accessibility.accessibilitymenu": {
     "list": "Aosp",
@@ -38048,7 +38048,7 @@
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   "com.xiaomi.oobhelper": {
     "list": "Oem",


### PR DESCRIPTION
## Description

- fixed category of com.android.runintest.ddrtest which isn't AOSP
- move com.android.safetycenter.resources because it only contains configs and breaks new safety center, doesn't contact google server itself
- move com.android.calllogbackup as uninstalling breaks call log backup
- move com.android.systemui.plugin.globalactions.wallet as uninstalling breaks google pay quick access
- move com.svox.pico as uninstalling breaks TTS
- move com.android.fmradio as uninstalling breaks FM Radio
- move com.android.health.connect.backuprestore as uninstalling breaks health connect backup and restore
- move com.android.healthconnect.controller as uninstalling breaks apps which rely on Health Connect
- move com.android.virtualmachine.res as uninstalling can be a security issue, as it declares permissions
- move com.google.android.apps.googlecamera.fishfood as uninstalling breaks Google Lens icon in Aperture
- move com.android.role.notes.enabled as it breaks toggling developer options

## Related issues

none

## Checklist

- [X] I have read the [CONTRIBUTING guidelines](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my changes
- [x] My changes generate no new warnings (how do I know?)
- [x] The CI/CD pipeline passes (or is expected to pass)