### PR TITLE
pkg(com.samsung.android.timezone.data_R): change description and removal

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -42146,10 +42146,10 @@
   },
   "com.samsung.android.timezone.data_R": {
     "list": "Oem",
-    "description": "Completely empty package. Useless. No issues with the clock after uninstalling",
+    "description": "Causes bootloop on Samsung Galaxy A50 (SM-A505FN). Rescue Party triggered, package manager service fails to start. Device becomes unbootable. Do NOT remove on older Samsung devices.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Unsafe"
   }
 }

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -42146,11 +42146,11 @@
   },
   "com.samsung.android.timezone.data_R": {
     "list": "Oem",
-    "description": "Completely empty package. Useless. No issues with the clock after uninstalling",
+    "description": "Causes bootloop on any Samsung Galaxy A50 when removed. \n Rescue Party will be triggered, package manager service will fail to start. \n Device becomes unbootable. Do NOT remove on older Samsung devices.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Unsafe"
   },
   "com.sec.android.usermanual": {
     "list": "Oem",

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -42146,7 +42146,7 @@
   },
   "com.samsung.android.timezone.data_R": {
     "list": "Oem",
-    "description": "Causes bootloop on Samsung Galaxy A50 (SM-A505FN). Rescue Party triggered, package manager service fails to start. Device becomes unbootable. Do NOT remove on older Samsung devices.",
+    "description": "Causes bootloop on any Samsung Galaxy A50. Rescue Party triggered, package manager service fails to start. Device becomes unbootable. Do NOT remove on older Samsung devices.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],


### PR DESCRIPTION
## Description
Changed the removal data for com.samsung.android.timezone.data_R to Unsafe and updated description.

- Package name: com.samsung.android.timezone.data_R
- Current list: Oem
  - Proposed list: Oem
- Current removal: Recommended
  - Proposed removal: Unsafe
- Current description: Completely empty package. Useless. No issues with the clock after uninstalling
  - Proposed description: Causes bootloop on any Samsung Galaxy A50. Rescue Party triggered, package manager service fails to start. Device becomes unbootable. Do NOT remove on older Samsung devices.

## Related issues

<!-- Link to related issues using keywords (e.g. Fixes <issue_number>) -->
<!-- Learn more: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->
Fixes #1358 

## Checklist

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] The CI/CD pipeline passes (or is expected to pass)

<!--
Optional: specialized templates are kept in .github/PULL_REQUEST_TEMPLATE/
For app/package/documentation-focused PRs, you can use it by including the template in the URL when creating the PR, e.g.
https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=app.md, https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=package.md or https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=documentation.md.
-->
