### PR TITLE
feat(gui:list): allow copying package-names

### DIFF
--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -342,8 +342,8 @@ impl List {
             .height(Length::FillPortion(6))
             .style(style::Scrollable::Packages);
 
-        let description_scroll = scrollable(text(&self.description_content).selectable(true))
-            .style(style::Scrollable::Description);
+        let description_scroll =
+            scrollable(text(self.description_content.text())).style(style::Scrollable::Description);
         let description_panel = container(description_scroll)
             .padding(6)
             .height(Length::FillPortion(2))

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -1571,4 +1571,3 @@ fn recap<'a>(settings: &Settings, recap: &SummaryEntry) -> Element<'a, Message, 
     .style(style::Container::Frame)
     .into()
 }
-

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -343,7 +343,9 @@ impl List {
             .style(style::Scrollable::Packages);
 
         let description_scroll =
-            scrollable(text(self.description_content.text())).style(style::Scrollable::Description);
+            scrollable(text_editor(&self.description_content).on_action(Message::DescriptionEdit))
+                .style(style::Scrollable::Description);
+
         let description_panel = container(description_scroll)
             .padding(6)
             .height(Length::FillPortion(2))
@@ -1569,3 +1571,4 @@ fn recap<'a>(settings: &Settings, recap: &SummaryEntry) -> Element<'a, Message, 
     .style(style::Container::Frame)
     .into()
 }
+

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -975,7 +975,7 @@ impl List {
                     }
                     if !toggle {
                         self.selected_packages.retain(|&x| x.1 != i_package);
-                    }
+                    }//
                 } else {
                     package.selected = toggle;
                     if toggle {

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -7,11 +7,12 @@ use crate::core::uad_lists::{
 };
 use crate::core::utils::{EXPORT_FILE_NAME, NAME, export_selection, fetch_packages, open_url};
 use crate::gui::style;
-use crate::gui::widgets::navigation_menu::ICONS;
-use std::path::PathBuf;
-
 use crate::gui::views::settings::Settings;
 use crate::gui::widgets::modal::Modal;
+use crate::gui::widgets::navigation_menu::ICONS;
+use crate::gui::widgets::package_row::Message as PackageRowMessage;
+use std::path::PathBuf;
+
 use crate::gui::widgets::package_row::{Message as RowMessage, PackageRow};
 use crate::gui::widgets::text;
 use iced::widget::scrollable::{Direction, Scrollbar};
@@ -952,6 +953,7 @@ impl List {
         let package = &mut self.phone_packages[i_user][i_package];
 
         match *row_message {
+            PackageRowMessage::Noop => Task::none(),
             RowMessage::ToggleSelection(toggle) => {
                 if package.removal == Removal::Unsafe && !settings.general.expert_mode {
                     package.selected = false;

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -342,9 +342,8 @@ impl List {
             .height(Length::FillPortion(6))
             .style(style::Scrollable::Packages);
 
-let description_scroll =
-    scrollable(text(&self.description_content).selectable(true))
-        .style(style::Scrollable::Description);
+        let description_scroll = scrollable(text(&self.description_content).selectable(true))
+            .style(style::Scrollable::Description);
         let description_panel = container(description_scroll)
             .padding(6)
             .height(Length::FillPortion(2))

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -975,7 +975,7 @@ impl List {
                     }
                     if !toggle {
                         self.selected_packages.retain(|&x| x.1 != i_package);
-                    }//
+                    }
                 } else {
                     package.selected = toggle;
                     if toggle {

--- a/src/gui/views/list.rs
+++ b/src/gui/views/list.rs
@@ -342,10 +342,9 @@ impl List {
             .height(Length::FillPortion(6))
             .style(style::Scrollable::Packages);
 
-        let description_scroll =
-            scrollable(text_editor(&self.description_content).on_action(Message::DescriptionEdit))
-                .style(style::Scrollable::Description);
-
+let description_scroll =
+    scrollable(text(&self.description_content).selectable(true))
+        .style(style::Scrollable::Description);
         let description_panel = container(description_scroll)
             .padding(6)
             .height(Length::FillPortion(2))

--- a/src/gui/widgets/package_row.rs
+++ b/src/gui/widgets/package_row.rs
@@ -128,7 +128,9 @@ impl PackageRow {
                     text_input("", &self.name)
                         .on_input(|_| Message::Noop)
                         .padding(0)
-                        .size(16),
+                        .size(14)
+                        .width(Length::FillPortion(8)),
+                    //
                     action_btn.style(button_style)
                 ]
                 .spacing(8)

--- a/src/gui/widgets/package_row.rs
+++ b/src/gui/widgets/package_row.rs
@@ -124,7 +124,7 @@ impl PackageRow {
             button(
                 row![
                     selection_checkbox,
-					// Allows the packagename text to be copyable
+                    // Allows the packagename text to be copyable
                     text_input("", &self.name)
                         .on_input(|_| Message::Noop)
                         .padding(0)

--- a/src/gui/widgets/package_row.rs
+++ b/src/gui/widgets/package_row.rs
@@ -124,13 +124,10 @@ impl PackageRow {
             button(
                 row![
                     selection_checkbox,
-                    //
                     text_input("", &self.name)
                         .on_input(|_| Message::Noop)
                         .padding(0)
-                        .size(14)
-                        .width(Length::FillPortion(8)),
-                    //
+                        .size(16),
                     action_btn.style(button_style)
                 ]
                 .spacing(8)

--- a/src/gui/widgets/package_row.rs
+++ b/src/gui/widgets/package_row.rs
@@ -124,7 +124,7 @@ impl PackageRow {
             button(
                 row![
                     selection_checkbox,
-                    // Allows the packagename text to be copyable
+                    // Allows the package name text to be copyable
                     text_input("", &self.name)
                         .on_input(|_| Message::Noop)
                         .padding(0)

--- a/src/gui/widgets/package_row.rs
+++ b/src/gui/widgets/package_row.rs
@@ -129,7 +129,7 @@ impl PackageRow {
                         .padding(0)
                         .size(16),
                     action_btn.style(button_style)
-                ]
+                ]//
                 .spacing(8)
                 .align_y(Alignment::Center)
             )

--- a/src/gui/widgets/package_row.rs
+++ b/src/gui/widgets/package_row.rs
@@ -124,6 +124,7 @@ impl PackageRow {
             button(
                 row![
                     selection_checkbox,
+					// Allows the packagename text to be copyable
                     text_input("", &self.name)
                         .on_input(|_| Message::Noop)
                         .padding(0)

--- a/src/gui/widgets/package_row.rs
+++ b/src/gui/widgets/package_row.rs
@@ -130,7 +130,6 @@ impl PackageRow {
                         .padding(0)
                         .size(14)
                         .width(Length::FillPortion(8)),
-                    //
                     action_btn.style(button_style)
                 ]
                 .spacing(8)

--- a/src/gui/widgets/package_row.rs
+++ b/src/gui/widgets/package_row.rs
@@ -129,7 +129,7 @@ impl PackageRow {
                         .padding(0)
                         .size(16),
                     action_btn.style(button_style)
-                ]//
+                ]
                 .spacing(8)
                 .align_y(Alignment::Center)
             )

--- a/src/gui/widgets/package_row.rs
+++ b/src/gui/widgets/package_row.rs
@@ -4,7 +4,7 @@ use crate::core::uad_lists::{PackageState, Removal, UadList};
 use crate::gui::style;
 use crate::gui::views::settings::Settings;
 use crate::gui::widgets::text;
-
+use iced::widget::text_input;
 use iced::widget::{Space, button, checkbox, row};
 use iced::{Alignment, Element, Length, Renderer, Task, alignment};
 
@@ -24,6 +24,7 @@ pub enum Message {
     PackagePressed,
     ActionPressed,
     ToggleSelection(bool),
+    Noop,
 }
 
 impl PackageRow {
@@ -123,7 +124,13 @@ impl PackageRow {
             button(
                 row![
                     selection_checkbox,
-                    text(&self.name).width(Length::FillPortion(8)),
+                    //
+                    text_input("", &self.name)
+                        .on_input(|_| Message::Noop)
+                        .padding(0)
+                        .size(14)
+                        .width(Length::FillPortion(8)),
+                    //
                     action_btn.style(button_style)
                 ]
                 .spacing(8)


### PR DESCRIPTION
## Description

<!-- Please include a clear summary of the changes in this pull request. -->
I have made it so that you can copy package names, if you select it or double click and use CTRL + C
## Related issues
closes #1304 
<!-- Link to related issues using keywords (e.g. Fixes <issue_number>) -->
<!-- Learn more: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Checklist

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] The CI/CD pipeline passes (or is expected to pass)

<!--
Optional: specialized templates are kept in .github/PULL_REQUEST_TEMPLATE/
For app/package/documentation-focused PRs, you can use it by including the template in the URL when creating the PR, e.g.
https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=app.md, https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=package.md or https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=documentation.md.
-->
