### PR TITLE
build(logo): optional `image` dep

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -42,7 +42,7 @@ jobs:
           restore-keys: ${{ runner.OS }}-release-
         if: matrix.os == 'ubuntu-22.04'
       - name: Building
-        run: cargo build --release --no-default-features --features wgpu,${{ matrix.update_feature }}
+        run: cargo build --release --no-default-features --features wgpu,${{ matrix.update_feature }},img
       - name: Renaming binaries [Windows]
         if: matrix.os == 'windows-2022'
         run: mv target/release/uad-ng.exe uad-ng-${{ matrix.build_target }}.exe

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ categories = ["gui"]
 edition = "2024"
 
 [features]
-default = ["wgpu", "self-update"]
+default = ["wgpu", "self-update", "img"]
 wgpu = [] # Iced/wgpu is default
 self-update = ["flate2", "tar"]
 no-self-update = []
+img = ["image", "iced/image"]
 
 [dependencies]
 dark-light = "2"
@@ -31,8 +32,8 @@ toml = "^0"
 dirs = "^6"
 ureq = { version = "3", features = ["json"] }
 retry = "^2.0.0"
-iced = { version = "=0.14.0", features = ["advanced", "image"] }
-image = "0.25"
+iced = { version = "=0.14.0", features = ["advanced"] }
+image = { version = "0.25", optional = true }
 rfd = "^0.17.1"
 csv = "^1.3"
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -4,13 +4,17 @@ pub mod widgets;
 
 use crate::core::adb;
 use crate::core::sync::{Phone, get_devices_list, initial_load};
-use crate::core::theme::{OS_COLOR_SCHEME, Theme};
+#[cfg(feature = "img")]
+use crate::core::theme::OS_COLOR_SCHEME;
+use crate::core::theme::Theme;
 use crate::core::uad_lists::UadListState;
 use crate::core::update::{Release, SelfUpdateState, SelfUpdateStatus, get_latest_release};
 use crate::core::utils::{FULL_NAME, NAME, string_to_theme};
 
 use iced::font;
+#[cfg(feature = "img")]
 use iced::window::icon;
+#[cfg(feature = "img")]
 use image::ImageFormat;
 use views::about::{About as AboutView, Message as AboutMessage};
 use views::list::{List as AppsView, LoadingState as ListLoadingState, Message as AppsMessage};
@@ -399,6 +403,7 @@ impl UadGui {
 
 impl UadGui {
     pub fn start() -> iced::Result {
+        #[cfg(feature = "img")]
         let logo: &[u8] = match *OS_COLOR_SCHEME {
             // remember to keep `Unspecified` in sync with `src/core/theme`
             dark_light::Mode::Dark | dark_light::Mode::Unspecified => {
@@ -425,6 +430,7 @@ impl UadGui {
                 },
                 resizable: true,
                 decorations: true,
+                #[cfg(feature = "img")]
                 icon: icon::from_file_data(logo, Some(ImageFormat::Png)).ok(),
                 ..iced::window::Settings::default()
             })


### PR DESCRIPTION
## Description

Make logo (the app icon) optional, so that `image` dependency is also optional

### Related issues

- mitigates #1335, not a proper fix, IMO

## How has this been tested?

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] Tested on the following environment(s):
  - OS: Linux (`cargo b --no-default-features`)
    - Desktop Environment: KDE Plasma
    - Window System/Manager: ?
  - Rust version: `rustc 1.96.0-nightly (02c7f9bec 2026-04-10)`

## Checklist

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have tested the application with these changes
- [x] The CI/CD pipeline passes
