### PR TITLE
pkg(com.xiaomi.cameramind): change description and removal

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -425,11 +425,11 @@
   },
   "com.xiaomi.cameramind": {
     "list": "Oem",
-    "description": "The core of all AI features for Xiaomi's camera app. Won't impact other camera apps' AI features.\nSafe to delete if you don't need them or if you use another camera app.",
+    "description": "The core of all AI features for Xiaomi's camera app. Won't impact other camera apps' AI features.\nSafe to delete if you use another camera app, otherwise, removal may cause background connection issues.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Advanced"
   },
   "com.xiaomi.bluetooth.rro.device.config.overlay": {
     "list": "Oem",

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -427,7 +427,9 @@
     "list": "Oem",
     "description": "The core of all AI features for Xiaomi's camera app. Won't impact other camera apps' AI features.\nSafe to delete if you use another camera app, otherwise, removal may cause background connection issues.",
     "dependencies": [],
-    "neededBy": [],
+    "neededBy": [
+      "com.android.camera"
+    ],
     "labels": [],
     "removal": "Advanced"
   },


### PR DESCRIPTION
## Description

On my Poco F8 Ultra, HyperOS 3.0.7.0, after debloating using the recommended list I've noticed constant error in the logcat that wasn't there before:

```
E IntentAwareCammsger: connect socket fail. Connection refused
```

The message repeats every 1 second, which clearly affects at the very least battery usage.

Going through the removed packages one by one, the removal that caused that was `com.xiaomi.cameramind`. Current description explains that no functionality is affected and the app can be safely removed - I can confirm that I didn't find any bootloops, camera crashes or stuff like that, that's true, however, constant error in the logcat every 1 second is definitely not desirable.

Since xiaomi's camera app is under `com.android.camera`, and removal of the android camera is considered advanced, I believe getting rid of `cameramind` should also be considered advanced in this case.

> Recommended: Any package that's safe to uninstall

> Advanced: Breaks obscure or minor parts of functionality

Even though I could not find outright major broken functionality, there's definitely something minor/obscure going on in the background to justify that it's not safe to remove, at least without constant battery drain if not more. It's totally OK if you have different opinion, although I'm acting in my best faith and I believe that this PR should be considered, not for me, as I've already restored that package on my phone, but for others. Therefore, I'm opening this PR for you to consider. Thanks in advance.

## Related issues

<!-- Link to related issues using keywords (e.g. Fixes <issue_number>) -->
<!-- Learn more: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

I didn't find any existing issue that relates to this PR, so you can consider this PR as an issue along with the suggested fix.

## Checklist

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] The CI/CD pipeline passes (or is expected to pass)

<!--
Optional: specialized templates are kept in .github/PULL_REQUEST_TEMPLATE/
For app/package/documentation-focused PRs, you can use it by including the template in the URL when creating the PR, e.g.
https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=app.md, https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=package.md or https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=documentation.md.
-->
