### PR TITLE
build: fix error and warnings

### DIFF
--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -122,7 +122,7 @@ pub fn fetch_packages(
             PackageRow::new(p_name, state, description, uad_list, removal, false, false);
         user_package.push(package_row);
     }
-    user_package.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    user_package.sort_by_key(|a| a.name.to_lowercase());
     user_package
 }
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -81,6 +81,7 @@ pub enum Message {
 }
 
 impl UadGui {
+    #[allow(clippy::unused_self)]
     fn title(&self) -> String {
         FULL_NAME.to_string()
     }
@@ -102,23 +103,21 @@ impl UadGui {
         )
     }
 
+    #[allow(clippy::unused_self)]
     fn subscription(&self) -> Subscription<Message> {
         event::listen_with(|event, _status, _env| match event {
-            iced::Event::Keyboard(keyboard::Event::KeyPressed { key, modifiers, .. })
-                if modifiers.control() && modifiers.shift() =>
-            {
-                match key {
-                    keyboard::Key::Character(c) => match c.as_str() {
-                        "r" => Some(Message::RebootButtonPressed),
-                        "5" => Some(Message::RefreshButtonPressed),
-                        "a" => Some(Message::AppsPress),
-                        "i" => Some(Message::AboutPressed),
-                        "s" => Some(Message::SettingsPressed),
-                        _ => None,
-                    },
-                    _ => None,
-                }
-            }
+            iced::Event::Keyboard(keyboard::Event::KeyPressed {
+                key: keyboard::Key::Character(c),
+                modifiers,
+                ..
+            }) if modifiers.control() && modifiers.shift() => match c.as_str() {
+                "r" => Some(Message::RebootButtonPressed),
+                "5" => Some(Message::RefreshButtonPressed),
+                "a" => Some(Message::AppsPress),
+                "i" => Some(Message::AboutPressed),
+                "s" => Some(Message::SettingsPressed),
+                _ => None,
+            },
             _ => None,
         })
     }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -81,7 +81,7 @@ pub enum Message {
 }
 
 impl UadGui {
-    #[allow(clippy::unused_self)]
+    #[allow(clippy::unused_self, reason = "required by iced's Application trait interface")]
     fn title(&self) -> String {
         FULL_NAME.to_string()
     }
@@ -103,7 +103,7 @@ impl UadGui {
         )
     }
 
-    #[allow(clippy::unused_self)]
+    #[allow(clippy::unused_self, reason = "required by iced's Application trait interface")]
     fn subscription(&self) -> Subscription<Message> {
         event::listen_with(|event, _status, _env| match event {
             iced::Event::Keyboard(keyboard::Event::KeyPressed {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -81,7 +81,10 @@ pub enum Message {
 }
 
 impl UadGui {
-    #[allow(clippy::unused_self, reason = "required by iced's Application trait interface")]
+    #[allow(
+        clippy::unused_self,
+        reason = "required by iced's Application trait interface"
+    )]
     fn title(&self) -> String {
         FULL_NAME.to_string()
     }
@@ -103,7 +106,10 @@ impl UadGui {
         )
     }
 
-    #[allow(clippy::unused_self, reason = "required by iced's Application trait interface")]
+    #[allow(
+        clippy::unused_self,
+        reason = "required by iced's Application trait interface"
+    )]
     fn subscription(&self) -> Subscription<Message> {
         event::listen_with(|event, _status, _env| match event {
             iced::Event::Keyboard(keyboard::Event::KeyPressed {

--- a/src/gui/widgets/navigation_menu.rs
+++ b/src/gui/widgets/navigation_menu.rs
@@ -13,6 +13,7 @@ pub const ICONS: Font = Font {
     ..Font::DEFAULT
 };
 
+#[allow(clippy::too_many_lines)]
 pub fn nav_menu<'a>(
     device_list: &'a [Phone],
     selected_device: Option<Phone>,


### PR DESCRIPTION
## Description

Address clippy suggestions and clean up pattern matching:

- Replace `manual sort_by` with `sort_by_key(|a| a.name.to_lowercase()) for user_package in fetch_packages`.
- Add `#[allow(clippy::unused_self)]` to `UadGui::title` and `UadGui::subscription` to silence `unused_self` warnings.
- Simplify the keyboard event match by destructuring the Character variant directly for clearer pattern matching.
- Add `#[allow(clippy::too_many_lines)]` to nav_menu to silence the long-function lint.

These are lint and readability-focused changes with no intended behavioral change.

## Checklist

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] The CI/CD pipeline passes (or is expected to pass)