### PR TITLE
pkg(com.motorola.securevault): change removal

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -20418,8 +20418,8 @@
     "labels": []
   },
   "com.motorola.securevault": {
-    "description": "Secure Folder\nUnnecessary tools to keep device secure.\nhttps://play.google.com/store/apps/details?id=com.motorola.securevault",
-    "removal": "Recommended",
+    "description": "Secure Folder\nNormally unnecessary tools to keep device secure, however, removal on motorola devices may cause background issues.\nhttps://play.google.com/store/apps/details?id=com.motorola.securevault",
+    "removal": "Advanced",
     "list": "Oem",
     "dependencies": [],
     "neededBy": [],

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -20418,7 +20418,7 @@
     "labels": []
   },
   "com.motorola.securevault": {
-    "description": "Secure Folder\nNormally unnecessary tools to keep device secure, however, removal on motorola devices may cause background issues.\nhttps://play.google.com/store/apps/details?id=com.motorola.securevault",
+    "description": "Secure Folder\nNormally unnecessary tools to keep device secure, however, removal may cause background issues - it should be safe to disable instead.\nhttps://play.google.com/store/apps/details?id=com.motorola.securevault",
     "removal": "Advanced",
     "list": "Oem",
     "dependencies": [],


### PR DESCRIPTION
## Description

<!-- Please include a clear summary of the changes in this pull request. -->

On my Motorola G15 Power, Android 15, build number VVTAS35.51-137-10-3, after debloating using the recommended list I've noticed constant error in the logcat that wasn't there before:

```
05-01 00:03:17.163  1555  3295 E SafeInvoker: Service invocation returned exception
05-01 00:03:17.163  1555  3295 E SafeInvoker: android.content.pm.PackageManager$NameNotFoundException: com.motorola.securevault
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at android.app.ApplicationPackageManager.getApplicationInfoAsUser(ApplicationPackageManager.java:524)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at android.app.ApplicationPackageManager.getApplicationInfo(ApplicationPackageManager.java:507)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at android.app.ApplicationPackageManager.getApplicationInfo(ApplicationPackageManager.java:501)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at android.app.ApplicationPackageManager.getResourcesForApplication(ApplicationPackageManager.java:2130)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at com.motorola.server.security.securevault.utils.Utils.getApplicationResourceIdentifier(Utils.java:82)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at com.motorola.server.security.securevault.utils.Utils.getVaultProfileFilterList(Utils.java:132)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at com.motorola.server.security.securevault.UserFilteringPolicy.lambda$shouldExcludeVaultProfile$0(UserFilteringPolicy.java:22)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at com.motorola.server.security.securevault.UserFilteringPolicy.$r8$lambda$jR7E2mX-Lw2CinGTcPdwj0zFoNY(UserFilteringPolicy.java:0)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at com.motorola.server.security.securevault.UserFilteringPolicy$$ExternalSyntheticLambda0.call(R8$$SyntheticClass:0)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at com.motorola.server.security.securevault.invoker.SafeInvoker.invokeWithClearCallingReturnable(SafeInvoker.java:65)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at com.motorola.server.security.securevault.invoker.SafeInvoker.invokeWithClearCallingWithBooleanReturn(SafeInvoker.java:99)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at com.motorola.server.security.securevault.UserFilteringPolicy.shouldExcludeVaultProfile(UserFilteringPolicy.java:19)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at com.motorola.server.security.securevault.SecureVault.shouldExcludeVaultProfile(SecureVault.java:378)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at com.motorola.server.security.MotoSecurityManagerService$1.shouldExcludeVaultProfile(MotoSecurityManagerService.java:449)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at com.motorola.internal.security.MotoSecurityManager.shouldExcludeVaultProfile(MotoSecurityManager.java:735)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at com.motorola.internal.security.MotoSecurityUtils.shouldExcludeVaultProfile(MotoSecurityUtils.java:240)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at com.android.server.pm.UserManagerService.getProfileIds(UserManagerService.java:1484)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at com.android.server.pm.UserManagerService.getProfileIds(UserManagerService.java:1467)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at android.os.IUserManager$Stub.onTransact(IUserManager.java:1126)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at android.os.Binder.execTransactInternal(Binder.java:1500)
05-01 00:03:17.163  1555  3295 E SafeInvoker:   at android.os.Binder.execTransact(Binder.java:1444)
```

The message repeats on usual basis, which clearly affects at the very least battery usage.

Finding the problematic package obviously wasn't big issue, restoring `com.motorola.securevault` fixed the problem immediately, without any clear potential missing further dependencies.

It seems the caller is `com.motorola.internal.security`, however, that's not a package possible to remove, so we can't link to that as `neededBy`.

Similar to issue #1382, I believe removal of this app therefore should be considered advanced.

> Recommended: Any package that's safe to uninstall

> Advanced: Breaks obscure or minor parts of functionality

Even though I could not find outright major broken functionality, there's definitely something minor/obscure going on in the background to justify that it's not safe to remove, at least without constant battery drain if not more. Therefore, I'm opening this PR for you to consider. Thanks in advance.

## Related issues

<!-- Link to related issues using keywords (e.g. Fixes <issue_number>) -->
<!-- Learn more: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

I didn't find any existing issue that relates to this PR, so you can consider this PR as an issue along with the suggested fix.

## Checklist

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] The CI/CD pipeline passes (or is expected to pass)

<!--
Optional: specialized templates are kept in .github/PULL_REQUEST_TEMPLATE/
For app/package/documentation-focused PRs, you can use it by including the template in the URL when creating the PR, e.g.
https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=app.md, https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=package.md or https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=documentation.md.
-->
