### PR TITLE
Add preloaded apps for Telefonica devices

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -43115,5 +43115,125 @@
     "neededBy": [],
     "labels": [],
     "removal": "Recommended"
+  },
+  "com.ea.worms": {
+    "list": "Carrier",
+    "description": "Worms. A videogame preloaded on Telefonica devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "com.glu.android.gunbros_iap_telefonica": {
+    "list": "Carrier",
+    "description": "Gun Brothers. A videogame preloaded on Telefonica devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "test.emocion": {
+    "list": "Carrier",
+    "description": "emocion. A browser preloaded on Telefonica devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "flipboard.app": {
+    "list": "Carrier",
+    "description": "Flipboard. A program preloaded on select devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "imagenio.movil.tv": {
+    "list": "Carrier",
+    "description": "Imagenio. A app preloaded on Telefonica devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "com.segundalinea.android": {
+    "list": "Carrier",
+    "description": "Segunda Linea. A app preloaded on Telefonica devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "com.gameloft.android.telefonica.GloftSRTB": {
+    "list": "Carrier",
+    "description": "Shark Dash. A videogame preloaded on Telefonica devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "com.realarcade.DOJ.TELEFONICA": {
+    "list": "Carrier",
+    "description": "Doodle Jump Plus. A videogame preloaded on Telefonica devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "com.movistar.recomienda": {
+    "list": "Carrier",
+    "description": "Movistar Recomienda. An Application preloaded on Telefonica devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "com.movistar.android.mimovistar.es": {
+    "list": "Carrier",
+    "description": "Mi Movistar 2. A app preloaded on Telefonica devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "com.dhr.spotify.launcher": {
+    "list": "Carrier",
+    "description": "Spotify. A app preloaded on Telefonica devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "com.glu.android.gunbros_iap_telefonica": {
+    "list": "Carrier",
+    "description": "Gun Brothers. A videogame preloaded on Telefonica devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "com.tuenti.messenger": {
+    "list": "Carrier",
+    "description": "Tuenti. A application preloaded on Telefonica devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "com.google.android.videos": {
+    "list": "Carrier",
+    "description": "Gun Brothers. A videogame preloaded on Telefonica devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+  "com.herocraft.game.yumsters.telefonica": {
+    "list": "Carrier",
+    "description": "Yumsters. A videogame preloaded on Telefonica devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
   }
 }

--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -43220,9 +43220,9 @@
     "labels": [],
     "removal": "Recommended"
   },
-  "com.google.android.videos": {
+  "uk.co.o2.android.o2space": {
     "list": "Carrier",
-    "description": "Gun Brothers. A videogame preloaded on Telefonica devices.",
+    "description": "O2 Appspace. A Application preloaded on O2 devices.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
@@ -43231,6 +43231,62 @@
   "com.herocraft.game.yumsters.telefonica": {
     "list": "Carrier",
     "description": "Yumsters. A videogame preloaded on Telefonica devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+    "com.herocraft.game.wonderwood": {
+    "list": "Carrier",
+    "description": "Wonder Wood. A game preloaded on Movistar devices.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+    "com.audible.application": {
+    "list": "Carrier",
+    "description": "Audible. A application preloaded on various carriers.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+    "uk.amazon.mShop": {
+    "list": "Carrier",
+    "description": "Mshop. A application preloaded on O2 UK.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+    "com.jvnewco.yaapmoney": {
+    "list": "Carrier",
+    "description": "Yaap Money. A application preloaded on various carriers.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+    "com.gameloft.android.GloftPDMF": {
+    "list": "Carrier",
+    "description": "Dragon Mania. A game preloaded on Movistar.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+    "com.ebay.mobile": {
+    "list": "Carrier",
+    "description": "eBay. A application preloaded on various carriers.",
+    "dependencies": [],
+    "neededBy": [],
+    "labels": [],
+    "removal": "Recommended"
+  },
+    "com.gameloft.android.GloftSMIF": {
+    "list": "Carrier",
+    "description": "Spiderman. A game preloaded on Movistar.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],


### PR DESCRIPTION
Added multiple applications with descriptions and removal recommendations for preloaded apps on Telefonica devices.

## Description

<!-- Please include a clear summary of the changes in this pull request. -->

Added various Telefonica (Spain) apps for Movistar

## Related issues

<!-- Link to related issues using keywords (e.g. Fixes <issue_number>) -->
<!-- Learn more: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Checklist

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] The CI/CD pipeline passes (or is expected to pass)

<!--
Optional: specialized templates are kept in .github/PULL_REQUEST_TEMPLATE/
For app/package/documentation-focused PRs, you can use it by including the template in the URL when creating the PR, e.g.
https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=app.md, https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=package.md or https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=documentation.md.
-->
