### PR TITLE
harden: validate package-name charset in request_builder

### DIFF
--- a/crates/uad-core/src/sync.rs
+++ b/crates/uad-core/src/sync.rs
@@ -206,6 +206,22 @@ pub fn apply_pkg_state_commands(
 /// which act on a common `package` and `user`.
 #[must_use]
 pub fn request_builder(commands: &[&str], package: &str, user: Option<User>) -> Vec<String> {
+    // Defense-in-depth: `package` is interpolated verbatim into a device-shell
+    // action, so refuse any name carrying a character that can't appear in a valid
+    // Android application-ID (`[A-Za-z0-9_.]`). Every current caller already
+    // reconciles the name against the live device package list before reaching
+    // here, so this rejects nothing legitimate — it just keeps the no-injection
+    // guarantee local to the sink instead of relying on each caller to sanitise.
+    // Fail closed: emit no command for a malformed name rather than an injectable
+    // device-shell string.
+    if package.is_empty()
+        || !package
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'.' || b == b'_')
+    {
+        error!("request_builder: refusing package name with invalid characters: {package:?}");
+        return Vec::new();
+    }
     let maybe_user_flag = user_flag(user);
     commands
         .iter()


### PR DESCRIPTION
## What

`request_builder` (`crates/uad-core/src/sync.rs`) builds the ADB shell action by interpolating the package name straight into the command string:

```rust
format!("{c}{maybe_user_flag} {package}")
```

Every current caller reconciles `package` against the live device package list before it reaches here (`fetch_packages`, `process_package_state_change`, `restore_backup`), so this is safe in practice today. The thing I noticed is just that the safety property lives in the callers, not in the sink — a future caller that passed an unreconciled or file-sourced name would turn this into device-shell command injection. No exploit path exists right now; this is purely defense-in-depth.

## Change

Add a small charset guard at the top of `request_builder`: reject any name containing a character that can't appear in a valid Android application-ID (`[A-Za-z0-9_.]`), failing closed (emit no command). This keeps the no-injection guarantee local to the sink instead of relying on each caller to sanitise.

- **Rejects nothing legitimate** — real package IDs are `[A-Za-z0-9_.]`-only, so no current call path changes behavior.
- I used a charset check rather than `PackageId::new` on purpose: `PackageId::new` also requires ≥2 dot-segments, which would reject valid single-segment system IDs like `android`.

Happy to adjust the shape if you'd prefer — reuse `PackageId`, add a unit test, or a `--` end-of-options separator instead. Offered as help, not a grade; feel free to push back.
