### PR TITLE
fix(core): two bugs blocking package operations on real devices

### DIFF
--- a/crates/uad-core/src/adb.rs
+++ b/crates/uad-core/src/adb.rs
@@ -372,7 +372,7 @@ impl PmCommand {
                     if PackageId::new(p).is_some() {
                         Some(String::from(p))
                     } else {
-                        warn!("list_packages_sys: skipping nonstandard package name: {p:?}");
+                        warn!("skipping nonstandard package name: {p:?}");
                         None
                     }
                 })

--- a/crates/uad-core/src/adb.rs
+++ b/crates/uad-core/src/adb.rs
@@ -44,7 +44,7 @@ use std::rc::Rc;
 use std::os::windows::process::CommandExt;
 
 use crate::utils::is_all_w_c;
-use log::{error, info};
+use log::{error, info, warn};
 
 /// Convert ADB output bytes to a trimmed UTF-8 string.
 /// Uses lossy conversion to prevent panics on non-UTF8 output from certain OEMs.
@@ -366,11 +366,15 @@ impl PmCommand {
         self.0.0.run().map(|pack_ls| {
             pack_ls
                 .lines()
-                .map(|p_ln| {
+                .filter_map(|p_ln| {
                     debug_assert!(p_ln.starts_with(PACK_PREFIX));
                     let p = &p_ln[PACK_PREFIX.len()..];
-                    debug_assert!(PackageId::new(p).is_some());
-                    String::from(p)
+                    if PackageId::new(p).is_some() {
+                        Some(String::from(p))
+                    } else {
+                        warn!("list_packages_sys: skipping nonstandard package name: {p:?}");
+                        None
+                    }
                 })
                 .collect()
         })

--- a/crates/uad-core/src/sync.rs
+++ b/crates/uad-core/src/sync.rs
@@ -213,7 +213,7 @@ pub fn request_builder(commands: &[&str], package: &str, user: Option<User>) -> 
     // guarantee local to the sink instead of relying on each caller to sanitise.
     // Fail closed: emit no command for a malformed name rather than an injectable
     // device-shell string.
-    if PackageId::new(package).is_some() {
+    if PackageId::new(package).is_none() {
         error!("request_builder: refusing invalid package name: {package:?}");
         return Vec::new();
     }


### PR DESCRIPTION
Thanks for this project! Extremely helpful.

## Summary

Two bugs caught building from source in debug mode and running against a real device (realme GT master edition, Android 13).

## Changes

**`crates/uad-core/src/adb.rs` — harden `list_packages_sys` against nonstandard package names**

`debug_assert!(PackageId::new(p).is_some())` panics in debug builds when a device has system packages that don't match Android's strict naming convention. This function is called during device discovery via `is_protected_user()`, so it blocks `uad devices` and GUI startup on affected devices.

Changed to `filter_map` — silently skips invalid entries instead of crashing.

**`crates/uad-core/src/sync.rs` — fix inverted guard in `request_builder`**

Commit b051be8 added a security guard rejecting malformed package names, but the condition was inverted (`is_some()` instead of `is_none()`). This made `request_builder` refuse every *valid* package name, breaking uninstall/disable/restore for all users on all devices.

## Testing

- `uad devices` now succeeds on a realme GT master edition (Android 13, SDK 33) where it previously panicked.
- `uad uninstall com.coloros.video` now succeeds where it previously logged "refusing invalid package name".