### PR TITLE
pkg(com.android.networkstack.tethering.inprocess): change description and removal

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -42228,11 +42228,11 @@
   },
   "com.android.networkstack.tethering.inprocess": {
     "list": "Oem",
-    "description": "Completely empty package. Useless.",
+    "description": "Causes a lockscreen loop on some Xiaomi devices. Provides TetherableWifiRegexs, the lack of which crashes systemui and miui.home.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Recommended"
+    "removal": "Unsafe"
   },
   "com.samsung.android.a20.d01.wallpapermulti": {
     "list": "Oem",


### PR DESCRIPTION
## Description

<!-- Please include a clear summary of the changes in this pull request. -->
Fix `com.android.networkstack.tethering.inprocess` being incorrectly marked as not doing anything and therefore being recommended. The package actually provides `tetherableWifiRegexs` the lack of which breaks the notification drawer and system launcher on MIUI, causing a lockscreen loop.

Logcat output with the package disabled:
```logcat
FATAL EXCEPTION: Launcher.Background
Process: com.miui.home, PID: 7483
java.lang.NullPointerException: Attempt to read from field 'java.lang.String[] android.net.TetheringConfigurationParcel.tetherableWifiRegexs' on a null object reference
at android.net.TetheringManager.getTetherableWifiRegexs(TetheringManager.java:1210)
at android.net.ConnectivityManager.getTetherableWifiRegexs(ConnectivityManager.java:2671)
at com.miui.launcher.utils.ConnectivityHelper.isTetheringSupported(ConnectivityHelper.java:13)
at com.miui.home.launcher.DeviceConfig.lambda$checkIsTetheringSupported$10(DeviceConfig.java:1773)
at com.miui.home.launcher.-$$Lambda$DeviceConfig$9R3IozFxgbwmVH-NTsWOjUFHwFw.run(Unknown Source:0)
at android.os.Handler.handleCallback(Handler.java:938)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:236)
at android.os.HandlerThread.run(HandlerThread.java:67)
FATAL EXCEPTION: SysUiBg
Process: com.android.systemui, PID: 7548
java.lang.NullPointerException: Attempt to read from field 'java.lang.String[] android.net.TetheringConfigurationParcel.tetherableWifiRegexs' on a null object reference
at android.net.TetheringManager.getTetherableWifiRegexs(TetheringManager.java:1210)
at android.net.ConnectivityManager.getTetherableWifiRegexs(ConnectivityManager.java:2671)
at miui.app.ToggleManager.<init>(ToggleManager.java:430)
at miui.app.ToggleManager.createInstance(ToggleManager.java:404)
at com.android.systemui.ToggleManagerController$2.run(ToggleManagerController.java:69)
at android.os.Handler.handleCallback(Handler.java:938)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:236)
at android.os.HandlerThread.run(HandlerThread.java:67)
```

## Related issues
https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/issues/1311#issuecomment-3960952763
https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/issues/1370#issue-4165160292
https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/issues/1401#issue-4414938800


<!-- Link to related issues using keywords (e.g. Fixes <issue_number>) -->
<!-- Learn more: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Checklist

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] The CI/CD pipeline passes (or is expected to pass)

<!--
Optional: specialized templates are kept in .github/PULL_REQUEST_TEMPLATE/
For app/package/documentation-focused PRs, you can use it by including the template in the URL when creating the PR, e.g.
https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=app.md, https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=package.md or https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=documentation.md.
-->
