### PR TITLE
feat(settings): disable-mode by default

### DIFF
--- a/crates/uad-core/src/config.rs
+++ b/crates/uad-core/src/config.rs
@@ -37,7 +37,7 @@ pub struct BackupSettings {
 pub struct DeviceSettings {
     /// Unique serial identifier
     pub device_id: String,
-    pub disable_mode: bool,
+    pub disable_mode: bool, // should be `enum RemovalMode`
     pub multi_user_mode: bool,
     #[serde(skip)]
     pub backup: BackupSettings,

--- a/crates/uad-core/src/sync.rs
+++ b/crates/uad-core/src/sync.rs
@@ -180,16 +180,19 @@ pub fn apply_pkg_state_commands(
             _ => vec![],
         },
         PackageState::Disabled => match package.state {
-            PackageState::Uninstalled | PackageState::Enabled => match phone.android_sdk {
-                sdk if sdk >= 23 => vec!["pm disable-user", "am force-stop", PM_CLEAR_PACK],
-                _ => vec![],
-            },
+            PackageState::Uninstalled | PackageState::Enabled => {
+                if supports_disabling(phone) {
+                    vec!["pm disable-user", "am force-stop", PM_CLEAR_PACK]
+                } else {
+                    vec![]
+                }
+            }
             _ => vec![],
         },
         PackageState::Uninstalled => match package.state {
             PackageState::Enabled | PackageState::Disabled => match phone.android_sdk {
-                sdk if sdk >= 23 => vec!["pm uninstall"], // > Android Marshmallow (6.0)
-                21 | 22 => vec!["pm hide", PM_CLEAR_PACK], // Android Lollipop (5.x)
+                sdk if sdk >= 23 => vec!["pm uninstall"], // > Marshmallow (6.0)
+                21 | 22 => vec!["pm hide", PM_CLEAR_PACK], // Lollipop (5.x)
                 _ => vec!["pm block", PM_CLEAR_PACK], // Disable mode is unavailable on older devices because the specific ADB commands need root
             },
             _ => vec![],
@@ -401,10 +404,11 @@ pub fn detect_cross_user_behavior(
     }
 }
 
-/// Minimum inclusive Android SDK version
-/// that supports multi-user mode.
-/// Lollipop 5.0
-pub const MULTI_USER_SDK: u8 = 21;
+#[must_use]
+pub const fn supports_disabling(dev: &Phone) -> bool {
+    // >= Marshmallow (6.0)
+    dev.android_sdk >= 23
+}
 
 /// Check if it might support multi-user mode,
 /// by simply comparing SDK version.
@@ -415,7 +419,8 @@ pub const MULTI_USER_SDK: u8 = 21;
 /// - <https://developer.android.com/reference/android/os/UserManager#supportsMultipleUsers()>
 #[must_use]
 pub const fn supports_multi_user(dev: &Phone) -> bool {
-    dev.android_sdk >= MULTI_USER_SDK
+    // >= Lollipop (5.0)
+    dev.android_sdk >= 21
 }
 
 /// Check if a `user_id` is protected on a device by trying

--- a/crates/uad-gui/src/views/settings.rs
+++ b/crates/uad-gui/src/views/settings.rs
@@ -19,7 +19,7 @@ use uad_core::{
     save::{backup_phone, list_available_backup_user, list_available_backups, restore_backup},
     sync::{
         AdbError, CorePackage, Phone, User, get_android_sdk, run_adb_shell_action,
-        supports_multi_user,
+        supports_disabling, supports_multi_user,
     },
     utils::{DisplayablePath, Error, NAME, export_packages, generate_backup_name, open_url},
 };
@@ -113,7 +113,7 @@ impl Settings {
     }
 
     fn handle_disable_mode(&mut self, phone: &Phone, toggled: bool) -> Task<Message> {
-        if phone.android_sdk >= 23 {
+        if supports_disabling(phone) {
             self.device.disable_mode = toggled;
             debug!("Config change: {self:?}");
             let mut config = Config::load_configuration_file();
@@ -170,8 +170,9 @@ impl Settings {
             None => {
                 self.device = DeviceSettings {
                     device_id: phone.adb_id.clone(),
+                    // see FAQ, and GH-issue #1426
+                    disable_mode: supports_disabling(phone),
                     multi_user_mode: supports_multi_user(phone),
-                    disable_mode: false,
                     backup,
                 };
             }
@@ -498,14 +499,14 @@ impl Settings {
             .size(20)
             .style(style::CheckBox::SettingsEnabled);
 
-        let disable_checkbox_style = if phone.android_sdk >= 23 {
+        let disable_checkbox_style = if supports_disabling(phone) {
             style::CheckBox::SettingsEnabled
         } else {
             style::CheckBox::SettingsDisabled
         };
 
         let disable_mode_descr =
-            text("In some cases, it can be better to disable a package instead of uninstalling it")
+            text("In many cases, it's better to disable a package instead of uninstalling it")
                 .style(style::Text::Commentary);
 
         let unavailable_btn = button(text("Unavailable").size(14))
@@ -522,7 +523,7 @@ impl Settings {
             .size(20)
             .style(disable_checkbox_style);
 
-        let disable_setting_row = if phone.android_sdk >= 23 {
+        let disable_setting_row = if supports_disabling(phone) {
             row![
                 disable_mode_checkbox,
                 Space::new().width(Length::Fill).height(Length::Shrink),


### PR DESCRIPTION
## Description

- feat(settings): `disable_mode=true` if device supports it; update description
- refactor: define `supports_disabling` and use it whenever possible
- refactor(sync): inline `MULTI_USER_SDK`, with tiny comment
- docs(sync): rm redundant "Android"

### Related issues

- closes #1426

## How has this been tested?

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] Tested on the following environment(s):
  - OS:
    - Desktop Environment:
    - Window System/Manager:
  - ADB version:
  - Rust version:

## Checklist

- [x] I have read the [CONTRIBUTING guidelines](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/blob/main/CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have tested the application with these changes
- [ ] The CI/CD pipeline passes
