### PR TITLE
pkg(com.xiaomi.bluetooth): change description and removal

### DIFF
--- a/resources/assets/uad_lists.json
+++ b/resources/assets/uad_lists.json
@@ -17554,11 +17554,11 @@
   },
   "com.xiaomi.bluetooth": {
     "list": "Oem",
-    "description": "MIUI Bluetooth Extension. Doesn't seem to affect bluetooth functionality. Tested on Poco M4 Pro 5G HyperOS 1.0.1.0. Note: If you deleted (com.xiaomi.xmsf) this package will likely send\"Bluetooth extension stopped working\" errors, uninstalling it removes them.",
+    "description": "MIUI Bluetooth Extension. Doesn't seem to affect bluetooth functionality. Can introduce a ~1s delay when switching audio playback apps; uninstalling fixes this issue. Tested on Poco M4 Pro 5G HyperOS 1.0.1.0. Note: If you deleted (com.xiaomi.xmsf) this package will likely send\"Bluetooth extension stopped working\" errors, uninstalling it removes them.",
     "dependencies": [],
     "neededBy": [],
     "labels": [],
-    "removal": "Expert"
+    "removal": "Recommended"
   },
   "com.xiaomi.bluetooth.overlay": {
     "list": "Oem",


### PR DESCRIPTION
## Description
Actually mark the package as recommended to uninstall. #698 suggested this, #821 updated the description to reflect it being a good idea but did not actually change its classification.

The real reason I'm opening a PR is: This application sucks. It added a ~1sec delay when switching apps playing sound on the Poco X8 Pro Max; YT -> YTMusic and back would play a fraction of a second of audio, then mute for a second, then resume playback. It was not a codec issue, imagine my surprise when it was an expert labelled bloatware app. Good riddance.

edit: Technically the issue recommended "Advanced", but I've seen no benefit to keeping this installed. You don't even need adb/Canta to uninstall this app, you can disable it directly from the Apps listing. This is more informative than anything, I would recommend removing it to everyone.
<!-- Please include a clear summary of the changes in this pull request. -->

## Related issues
The issue is already closed. But it was not fixed. Let's try again.
<!-- Link to related issues using keywords (e.g. Fixes <issue_number>) -->
<!-- Learn more: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->

## Checklist

- [ ] I have read the [CONTRIBUTING guidelines](https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings
- [x] The CI/CD pipeline passes (or is expected to pass)

<!--
Optional: specialized templates are kept in .github/PULL_REQUEST_TEMPLATE/
For app/package/documentation-focused PRs, you can use it by including the template in the URL when creating the PR, e.g.
https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=app.md, https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=package.md or https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/pull/new/<branch_name>?template=documentation.md.
-->
